### PR TITLE
fix(block_relay): wrong message in modifiers

### DIFF
--- a/contracts/BlockRelay.sol
+++ b/contracts/BlockRelay.sol
@@ -43,12 +43,12 @@ contract BlockRelay {
   }
   // Ensures block exists
   modifier blockExists(uint256 _id){
-    require(blocks[_id].drHashMerkleRoot!=0, "Non-existing block");
+    require(blocks[_id].drHashMerkleRoot!=0, "The block already existed");
     _;
   }
    // Ensures block does not exist
   modifier blockDoesNotExist(uint256 _id){
-    require(blocks[_id].drHashMerkleRoot==0, "The block already existed");
+    require(blocks[_id].drHashMerkleRoot==0, "Non-existing block");
     _;
   }
 
@@ -71,6 +71,7 @@ contract BlockRelay {
     lastBlock.epoch = _epoch;
     blocks[id].drHashMerkleRoot = _drMerkleRoot;
     blocks[id].tallyHashMerkleRoot = _tallyMerkleRoot;
+    emit NewBlock(witnet, id);
   }
 
   /// @dev Retrieve the requests-only merkle root hash that was reported for a specific block header.

--- a/contracts/WitnetBridgeInterface.sol
+++ b/contracts/WitnetBridgeInterface.sol
@@ -365,11 +365,11 @@ contract WitnetBridgeInterface {
     return false;
   }
 
-  /// @dev Verifies the validity of a PoI
+  /// @dev Verifies the validity of a PoI of a DR
   /// @param _poi the proof of inclusion as [leaf1, leaf2,..]
   /// @param _root the merkle root
   /// @param _index the index in the merkle tree of the element to verify
-  /// @param _element the element
+  /// @param _element the element to hash together with the _poi, usually will be the hash of the result
   /// @return true or false depending the validity
   function verifyPoi(
     uint256[] memory _poi,
@@ -380,6 +380,8 @@ contract WitnetBridgeInterface {
   {
     uint256 tree = _element;
     uint256 index = _index;
+    // We want to prove that the hash of the _poi and the _element is equal to _root
+    // For knowing if concatenate to the left or the right we check the parity of the the index
     for (uint i = 0; i<_poi.length; i++) {
       if (index%2 == 0) {
         tree = uint256(sha256(abi.encodePacked(tree, _poi[i])));

--- a/test/block_relay.js
+++ b/test/block_relay.js
@@ -38,7 +38,7 @@ contract("Block relay", accounts => {
       const merkleRoot = 1
       await truffleAssert.reverts(blockRelayInstance.postNewBlock(expectedId, epoch, drRoot, merkleRoot, {
         from: accounts[0],
-      }), "The block already existed.")
+      }), "Non-existing block")
     })
     it("should insert another block", async () => {
       const expectedId = "0x" + sha.sha256("second id")
@@ -95,10 +95,10 @@ contract("Block relay", accounts => {
       const expectedId = "0x" + sha.sha256("forth id")
       await truffleAssert.reverts(blockRelayInstance.readDrMerkleRoot(expectedId, {
         from: accounts[1],
-      }), "Non-existing block")
+      }), "The block already existed")
       await truffleAssert.reverts(blockRelayInstance.readTallyMerkleRoot(expectedId, {
         from: accounts[1],
-      }), "Non-existing block")
+      }), "The block already existed")
     })
   })
 })

--- a/test/rad_error.js
+++ b/test/rad_error.js
@@ -1,0 +1,141 @@
+const WBI = artifacts.require("WitnetBridgeInterface")
+const BlockRelay = artifacts.require("BlockRelay")
+const UsingWitnetTestHelper = artifacts.require("UsingWitnetTestHelper")
+const Request = artifacts.require("Request")
+const Witnet = artifacts.require("Witnet")
+
+const sha = require("js-sha256")
+const data = require("./data.json")
+
+contract("UsingWitnet", accounts => {
+  describe("UsingWitnet2 \"happy path\" test case. " +
+    "This covers the life cycle of a Witnet request whose result is false.", () => {
+    const requestHex = "0x02"
+    const resultHex = "0xd82701"
+    const block1Hash = 0x123456
+    const block2Hash = 0xabcdef
+    const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    const requestReward = 7000000000000000
+    const resultReward = 3000000000000000
+
+    let witnet, clientContract, wbi, blockRelay, request, requestId, requestHash, result
+    let lastAccount0Balance, lastAccount1Balance
+
+    before(async () => {
+      witnet = await Witnet.deployed()
+      blockRelay = await BlockRelay.deployed({
+        from: accounts[0],
+      })
+      wbi = await WBI.deployed(blockRelay.address)
+      await UsingWitnetTestHelper.link(Witnet, witnet.address)
+      clientContract = await UsingWitnetTestHelper.new(wbi.address)
+      lastAccount0Balance = await web3.eth.getBalance(accounts[0])
+      lastAccount1Balance = await web3.eth.getBalance(accounts[1])
+    })
+
+    it("should create a Witnet request", async () => {
+        // Uso Request.sol para la dr que quiero para tener el hash de requestHex
+        request = await Request.new(requestHex)
+        const internalBytes = await request.bytecode()
+        // "droid" here stands for "data request output identifier"
+        const internalDroid = (await request.id()).toString(16)
+        const expectedDroid = sha.sha256(web3.utils.hexToBytes(requestHex))
+  
+        assert.equal(internalBytes, requestHex)
+        assert.equal(internalDroid, expectedDroid)
+      })
+
+    it("should pass the data request to the wbi", async () => {
+        // Uso Request.sol para la dr que quiero para tener el hash de requestHex
+        requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+            from: accounts[0],
+            value: requestReward + resultReward,
+        }))
+        assert.equal(requestId.toString(16), "0x0000000000000000000000000000000000000000000000000000000000000001")
+      })
+     
+    it("should report a Witnet block containing the request into the WBI", async () => {
+        const epoch = 1
+  
+        // "droid" here stands for "data request output identifier"
+        const droidHex = sha.sha256(web3.utils.hexToBytes(requestHex))
+        const droidBytes = web3.utils.hexToBytes(`0x${droidHex}`)
+        const drRootBytes = web3.utils.hexToBytes("0xe1504f07d07c513c7cd919caec111b900c893a5f9ba82c4243893132aaf087f8")
+  
+        requestHash = sha.sha256.create()
+        requestHash.update(droidBytes)
+        requestHash.update(drRootBytes)
+        requestHash = `0x${requestHash.hex()}`
+
+        await returnData(blockRelay.postNewBlock(block1Hash, epoch, requestHash, nullHash, {
+          from: accounts[0],
+        }))
+    
+      })
+
+      it("should prove inclusion of the request into Witnet", async () => {
+        const drRootHex = sha.sha256(web3.utils.hexToBytes(requestHex))
+        const drRootBytes = web3.utils.hexToBytes(`0x${drRootHex}`)
+
+        await returnData(wbi.reportDataRequestInclusion(requestId,
+          ["0xe1504f07d07c513c7cd919caec111b900c893a5f9ba82c4243893132aaf087f8"],
+          0,
+          block1Hash), {
+          from: accounts[1],
+        })
+        
+        const requestInfo = await wbi.requests(requestId)
+        assert.equal(`0x${requestInfo.drHash.toString(16)}`, requestHash)
+      })
+
+      it("should report a block containing the result into the WBI", async () => {
+        const epoch = 2
+        let resultHash = sha.sha256.create()
+        resultHash.update(web3.utils.hexToBytes(requestHash))
+        resultHash.update(web3.utils.hexToBytes(resultHex))
+        resultHash = `0x${resultHash.hex()}`
+  
+        await blockRelay.postNewBlock(block2Hash, epoch, nullHash, resultHash, { from: accounts[0] })
+      })
+
+      it("Should report the result in the WBI", async () => {
+        await returnData(wbi.reportResult(requestId, [], 0, block2Hash, resultHex))
+        const requestinfo = await wbi.requests(requestId)
+        assert.equal(requestinfo.result, resultHex)
+      })
+
+      it("Should pull the result from the wbi back to the client contract", async () => {
+        await clientContract._witnetReadResult(requestId, {from: accounts[0]} )
+        result = await clientContract.result()
+        assert.equal(result.cborValue.buffer.data, resultHex)
+
+
+      }) 
+
+      it("Should detect the result is false", async () => {
+        await clientContract._witnetReadResult(requestId, {from: accounts[0]} )
+        result = await clientContract.result()
+        assert.equal(result.success, false)
+
+
+      }) 
+  
+})
+})
+
+
+function waitForHash (tx) {
+    return new Promise((resolve, reject) =>
+      tx.on("transactionHash", resolve).catch(reject)
+    )
+  }
+  
+  async function returnData (tx) {
+    const txHash = await waitForHash(tx)
+    const txReceipt = await web3.eth.getTransactionReceipt(txHash)
+    if (txReceipt.logs[0]) {
+      return txReceipt.logs[0].data
+    }
+  }
+  

--- a/test/wbi.js
+++ b/test/wbi.js
@@ -373,7 +373,7 @@ contract("WBI", accounts => {
       // should fail to read blockhash from a non-existing block
       await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySibling], 2, fakeBlockHeader, {
         from: accounts[1],
-      }), "Non-existing block")
+      }), "The block already existed")
     })
     it("should revert because the rewards are higher than the values sent. " +
        "Checks the post data request transaction",

--- a/test/wbi.js
+++ b/test/wbi.js
@@ -325,7 +325,7 @@ contract("WBI", accounts => {
       })
     })
 
-    it("should revert the transacation when trying to read from a non-existent block", async () => {
+    it("should revert the transaction when trying to read from a non-existent block", async () => {
       const drBytes = web3.utils.fromAscii("This is a DR")
       const resBytes = web3.utils.fromAscii("This is a result")
       const halfEther = web3.utils.toWei("0.5", "ether")
@@ -375,7 +375,7 @@ contract("WBI", accounts => {
         from: accounts[1],
       }), "Non-existing block")
     })
-    it("should revert because the rewards are higher than the values sent." +
+    it("should revert because the rewards are higher than the values sent. " +
        "Checks the post data request transaction",
     async () => {
       const drBytes = web3.utils.fromAscii("This is a DR")


### PR DESCRIPTION
Fix small errors in the modifiers in blockExists and blockDoesNotExist.
Exchanges the messages between them.