### PR TITLE
feat(block_relay): add new contract and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ The `NewBlockRelay` contract is similar to the `BlockRelay` but adds some proper
 - Each block when proposed is connected to block in the previous epoch. This way when a block is posted, in case the previous epochs were not finalized, the previous blocks are posted as well.
 
 - **proposeBlock**:
-  - _description_: proposes a new block to eventually be added to the block relay.
+  - _description_: proposes a new block candidate to be considered be added to the block relay.
   - _inputs_:
     - *_blockHash*: Hash of the block header.
-    - *_epoch*: the epoch the block is prposed to, it has to be one epoch previous to the current epoch.
+    - *_epoch*: the epoch the block is prposed for, it has to be one epoch previous to the current epoch.
     - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
     - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
-    - *_previousBlock*: the previousVote is considered to be the valid block for the previous epoch.
+    - *_previousBlock*: the previousVote that this proposed block vote extends.
   - _modifiers_: Conditions  to be satiesfied before proposing a block:
     - _validEpoch_: A block can be proposed just for one epoch before the current epoch.
     - _absMembership_: Only members of the ABS (Active Bridge Set) can propose blocks.
@@ -149,7 +149,7 @@ The `NewBlockRelay` contract is similar to the `BlockRelay` but adds some proper
     - *_epoch*: the epoch for which the block was proposed.
     - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
     - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
-    - *_previousVote*: the previousVote includes the valid block for the previous epoch.
+    - *_previousVote*: the previousVote that this posted block vote extends.
 
 ## UsingWitnet
 
@@ -184,7 +184,11 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
 ## Known limitations:
 
 - `BlockRelay` is centralized at the moment (only the deployer of the contract is able to push blocks). In the future incentives will be established to decentralize block header reporting.
-- `NewBlockRelay`: The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment. At the moment, it is only allowed to propose blocks for one epoch before the current epoch in Witnet.
+- `NewBlockRelay`:
+
+      - The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment.
+      - At the moment, it is only allowed to propose blocks for one epoch before the current epoch in Witnet.
+      - `proposeBlock` can be called more than once.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `NewBlockRelay` contract is similar to the `BlockRelay` but adds some proper
 
 - Before posted, the blocks are proposed by members of the ABS.
 - When a block is proposed by 2/3 of the members of the ABS, it is posted and that epoch is set as finalized.
-- Each block when proposed is connected to block in the previous epoch. This way when a block is posted, in case the previous epochs were not finalized, the previous blocks are posted as well.
+- Each block when proposed is connected to a block in the previous epoch. This way, when a block is posted, in case the previous epochs were not finalized, the previous blocks are posted as well.
 
 - **proposeBlock**:
   - _description_: proposes a new block candidate to be considered be added to the block relay.
@@ -137,9 +137,6 @@ The `NewBlockRelay` contract is similar to the `BlockRelay` but adds some proper
     - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
     - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
     - *_previousBlock*: the previousVote that this proposed block vote extends.
-  - _modifiers_: Conditions  to be satiesfied before proposing a block:
-    - _validEpoch_: A block can be proposed just for one epoch before the current epoch.
-    - _absMembership_: Only members of the ABS (Active Bridge Set) can propose blocks.
 
 - **postNewBlock**:
   - _description_: post a new block into the block relay.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,32 @@ The `BlockRelay` contract has the following methods:
   - _output_:
     - the last beacon as byte concatenation of (block_hash||epoch).
 
+## NewBlockRelay
+
+The `NewBlockRelay` contract is similar to the `BlockRelay` but adds the following methods:
+
+- **proposeBlock**:
+  - _description_: proposes a new block to eventually be added to the block relay.
+  - _inputs_:
+    - *_blockHash*: Hash of the block header.
+    - *_epoch*: the epoch the block is prposed to, it has to be one epoch previous to the current epoch.
+    - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
+    - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
+    - *_previousBlock*: the previousVote is considered to be the valid block for the previous epoch.
+  - _modifiers_: Conditions  to be satiesfied before proposing a block:
+    - _validEpoch_: A block can be proposed just for one epoch before the current epoch.
+    - _absMembership_: Only members of the ABS (Active Bridge Set) can propose blocks.
+
+- **postNewBlock**:
+  - _description_: post a new block into the block relay.
+  - _inputs_:
+    - *_vote*: the vote to be posted .
+    - *_blockHash*: Hash of the block header.
+    - *_epoch*: the epoch for which the block was proposed.
+    - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
+    - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
+    - *_previousVote*: the previousVote is considered to be the valid block for the previous epoch.
+
 ## UsingWitnet
 
 The `UsingWitnet` contract injects the following methods into the contracts inheriting from it:
@@ -154,6 +180,7 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
 ## Known limitations:
 
 - `BlockRelay` is centralized at the moment (only the deployer of the contract is able to push blocks). In the future incentives will be established to decentralize block header reporting.
+- `NewBlockRelay`: The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -180,12 +180,8 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
 
 ## Known limitations:
 
-- `BlockRelay` is centralized at the moment (only the deployer of the contract is able to push blocks). In the future incentives will be established to decentralize block header reporting.
-- `NewBlockRelay`:
-
-      - The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment.
-      - At the moment, it is only allowed to propose blocks for one epoch before the current epoch in Witnet.
-      - `proposeBlock` can be called more than once.
+- `BlockRelay`: is centralized at the moment (only the deployer of the contract is able to push blocks). In the future incentives will be established to decentralize block header reporting.
+- `NewBlockRelay`: the ABS stays the same until a block is finalized. A block can be proposed more than once by the same ABS member and olny for one epoch before the current epoch.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ The `BlockRelay` contract has the following methods:
 
 ## NewBlockRelay
 
-The `NewBlockRelay` contract is similar to the `BlockRelay` but adds the following methods:
+The `NewBlockRelay` contract is similar to the `BlockRelay` but adds some properties:
+
+- Before posted, the blocks are proposed by members of the ABS.
+- When a block is proposed by 2/3 of the members of the ABS, it is posted and that epoch is set as finalized.
+- Each block when proposed is connected to block in the previous epoch. This way when a block is posted, in case the previous epochs were not finalized, the previous blocks are posted as well.
 
 - **proposeBlock**:
   - _description_: proposes a new block to eventually be added to the block relay.
@@ -140,12 +144,12 @@ The `NewBlockRelay` contract is similar to the `BlockRelay` but adds the followi
 - **postNewBlock**:
   - _description_: post a new block into the block relay.
   - _inputs_:
-    - *_vote*: the vote to be posted .
+    - *_vote*: the vote to be posted, this is the hash of the concatenation of the inputs of ´propopseBlock´.
     - *_blockHash*: Hash of the block header.
     - *_epoch*: the epoch for which the block was proposed.
     - *_drMerkleRoot*: the root hash of the requests-only merkle tree as contained in the block header.
     - *_tallyMerkleRoot*: the root hash of the tallies-only merkle tree as contained in the block header.
-    - *_previousVote*: the previousVote is considered to be the valid block for the previous epoch.
+    - *_previousVote*: the previousVote includes the valid block for the previous epoch.
 
 ## UsingWitnet
 
@@ -180,7 +184,7 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
 ## Known limitations:
 
 - `BlockRelay` is centralized at the moment (only the deployer of the contract is able to push blocks). In the future incentives will be established to decentralize block header reporting.
-- `NewBlockRelay`: The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment.
+- `NewBlockRelay`: The ABS for an epoch can finalize a block and previous epochs blocks if the consensus was not achieved even if they were not part of the ABS at that moment. At the moment, it is only allowed to propose blocks for one epoch before the current epoch in Witnet.
 
 ## Usage
 

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -83,6 +83,25 @@ library ActiveBridgeSetLib {
     return true;
   }
 
+  /// @dev Checks if an address is a memeber of the ABS
+  /// @param _abs The Active Bridge Set structure containing the last block.
+  /// @param _address The address to check.
+  /// @return true or false
+  function absMembership(ActiveBridgeSet storage _abs, address _address) internal returns (bool) {
+    uint256 blockNumber = block.number;
+    (uint16 currentSlot, uint16 lastSlot, bool overflow) = getSlots(_abs, blockNumber);
+    updateABS(
+      _abs,
+      currentSlot,
+      lastSlot,
+      overflow);
+    for (uint i; i < _abs.epochIdentities[lastSlot].length;) {
+      if (_abs.epochIdentities[lastSlot][i] == _address) {
+        return true;
+        }
+      }
+  }
+
   /// @dev Gets the slots of the last block seen by the ABS provided and the block number provided.
   /// @param _abs The Active Bridge Set structure containing the last block.
   /// @param _blockNumber The block number from which to get the current slot.

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 
 /**
  * @title Active Bridge Set (ABS) library
- * @notice This library counts the number of bridges that were active recently.
+ * @notice This library counts the number of bridges that were active recently
  */
 library ActiveBridgeSetLib {
 
@@ -83,7 +83,7 @@ library ActiveBridgeSetLib {
     return true;
   }
 
-  /// @dev Checks if an address is a memeber of the ABS
+  /// @dev Checks if an address is a member of the ABS
   /// @param _abs The Active Bridge Set structure from the Witnet Bridge Interface.
   /// @param _address The address to check.
   /// @return true or false

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -84,7 +84,7 @@ library ActiveBridgeSetLib {
   }
 
   /// @dev Checks if an address is a memeber of the ABS
-  /// @param _abs The Active Bridge Set structure containing the last block.
+  /// @param _abs The Active Bridge Set structure from the Witnet Bridge Interface.
   /// @param _address The address to check.
   /// @return true or false
   function absMembership(ActiveBridgeSet storage _abs, address _address) internal returns (bool) {

--- a/contracts/NewBlockRelay.sol
+++ b/contracts/NewBlockRelay.sol
@@ -147,6 +147,7 @@ contract NewBlockRelay is WitnetBridgeInterface {
   /// @param _epoch Epoch for which the block is proposed
   /// @param _drMerkleRoot Merkle root belonging to the data requests
   /// @param _tallyMerkleRoot Merkle root belonging to the tallies
+  /// @param _previousVote Hash of block's hashes proposed in the previous epoch
   function proposeBlock(
     uint256 _blockHash,
     uint256 _epoch,
@@ -300,10 +301,12 @@ contract NewBlockRelay is WitnetBridgeInterface {
   }
 
   /// @dev Post new block into the block relay
+  /// @param _vote Vote created when the block was proposed
   /// @param _blockHash Hash of the block headerPost
   /// @param _epoch Witnet epoch to which the block belongs to
   /// @param _drMerkleRoot Merkle root belonging to the data requests
   /// @param _tallyMerkleRoot Merkle root belonging to the tallies
+  /// @param _previousVote Hash of block's hashes proposed in the previous epoch
   function postNewBlock(
     uint256 _vote,
     uint256 _blockHash,

--- a/contracts/NewBlockRelay.sol
+++ b/contracts/NewBlockRelay.sol
@@ -1,0 +1,404 @@
+pragma solidity ^0.5.0;
+
+import "./ActiveBridgeSetLib.sol";
+import "./WitnetBridgeInterface.sol";
+
+
+/**
+ * @title New Block relay contract
+ * @notice Contract to store/read block headers from the Witnet network
+ * @author Witnet Foundation
+ */
+contract NewBlockRelay is WitnetBridgeInterface {
+
+  struct MerkleRoots {
+    // hash of the merkle root of the DRs in Witnet
+    uint256 drHashMerkleRoot;
+    // hash of the merkle root of the tallies in Witnet
+    uint256 tallyHashMerkleRoot;
+    uint256 previousVote;
+  }
+
+  struct Beacon {
+    // hash of the last block
+    uint256 blockHash;
+    // epoch of the last block
+    uint256 epoch;
+  }
+
+  // Struct with the hashes of a votation
+  struct Hashes {
+    uint256 blockHash;
+    uint256 drMerkleRoot;
+    uint256 tallyMerkleRoot;
+    uint256 previousVote;
+  }
+
+  struct FinalizedBlock {
+    string status;
+    uint256 blockHash;
+  }
+
+  struct VoteInfo {
+    uint256 numberOfVotes;
+    Hashes voteHashes;
+  }
+
+  // Array with the votes for the proposed blocks
+  uint256[] public candidates;
+
+  // Initializes the block with the maximum number of votes
+  uint256 winnerVote;
+  uint256 winnerId = 0;
+  uint256 winnerDrMerkleRoot = 0;
+  uint256 winnerTallyMerkleRoot = 0;
+  uint256 winnerEpoch = 0;
+
+  // Needed for the constructor
+  uint256 witnetGenesis;
+  uint256 epochSeconds;
+  uint256 firstBlock;
+
+  // Initializes the current epoch and the epoch in which it is valid to propose blocks
+  uint256 currentEpoch;
+  uint256 proposalEpoch;
+
+  // Initializes the tied vote count
+  uint256 tiedVote;
+
+  uint256 activeIdentities = uint256(abs.activeIdentities);
+
+  // Last block reported
+  Beacon public lastBlock;
+
+  // Map a vote proposed to the number of votes recieved and its hashes
+  mapping(uint256=> VoteInfo) internal voteInfo;
+
+  /* Map the hash of the block to the merkle roots.
+  It is used as an easy way to check if a blockHash already exists*/
+  mapping (uint256 => MerkleRoots) public blocks;
+
+  // Map an epoch to the finalized block
+  mapping(uint256 => FinalizedBlock) internal epochFinalizedBlock;
+
+ // Event emitted when there's been a tie during the votation process
+  event Tie(string _tie);
+
+  constructor(uint256 _witnetGenesis, uint256 _epochSeconds, uint256 _firstBlock) WitnetBridgeInterface(address(this), 2) public{
+    // Set the first epoch in Witnet plus the epoch duration when deploying the contract
+    witnetGenesis = _witnetGenesis;
+    epochSeconds = _epochSeconds;
+    firstBlock = _firstBlock;
+  }
+
+  // Ensures block exists
+  modifier blockExists(uint256 _id){
+    require(blocks[_id].drHashMerkleRoot!=0, "Non-existing block");
+    _;
+  }
+   // Ensures block does not exist
+  modifier blockDoesNotExist(uint256 _id){
+    require(blocks[_id].drHashMerkleRoot==0, "The block already existed");
+    _;
+  }
+
+   //  Ensures that neither Poi nor PoE are allowed if the epoch is pending
+  modifier finalizedEpoch(uint256 _epoch){
+    require(
+      keccak256(abi.encodePacked((epochFinalizedBlock[_epoch].status))) ==
+      keccak256(abi.encodePacked(("Finalized"))),
+      "The block has not been finalized");
+    _;
+  }
+
+   //  Ensures that the msg.sender is in the abs
+  modifier absMembership(address _address){
+    require(abs.absMembership(_address) == true, "Not a member of the abs");
+    _;
+  }
+
+
+  modifier noTie(){
+    if (tiedVote != winnerVote) {
+      require(voteInfo[tiedVote].numberOfVotes < voteInfo[winnerVote].numberOfVotes, "There has been a tie");
+    }
+    _;
+  }
+
+/* Ensures the epoch for which the block is been proposed is valid
+   Valid if it is one epoch before the current epoch */
+  modifier validEpoch(uint256 _epoch){
+    currentEpoch = updateEpoch();
+    if (proposalEpoch == 0) {
+      proposalEpoch = currentEpoch;
+    }
+    require(currentEpoch - 1 == _epoch, "Proposing a block for a non valid epoch");
+    _;
+  }
+
+
+  /// @dev Updates the epoch
+  function updateEpoch() public view returns(uint256) {
+    return (block.timestamp - witnetGenesis)/epochSeconds;
+  }
+
+  /// @dev Proposes a block into the block relay
+  /// @param _blockHash Hash of the block header
+  /// @param _epoch Epoch for which the block is proposed
+  /// @param _drMerkleRoot Merkle root belonging to the data requests
+  /// @param _tallyMerkleRoot Merkle root belonging to the tallies
+  function proposeBlock(
+    uint256 _blockHash,
+    uint256 _epoch,
+    uint256 _drMerkleRoot,
+    uint256 _tallyMerkleRoot,
+    uint256 _previousVote
+    )
+    public
+    validEpoch(_epoch)
+    absMembership(msg.sender)
+    returns(bytes32)
+  {
+    // Post new block if the proposal epoch has changed
+    if (currentEpoch > proposalEpoch) {
+
+      postNewBlock(
+        winnerVote,
+        winnerId,
+        winnerEpoch,
+        winnerDrMerkleRoot,
+        winnerTallyMerkleRoot,
+        voteInfo[winnerVote].voteHashes.previousVote);
+      // Update the proposal epoch
+      proposalEpoch = currentEpoch;
+    }
+
+    // Hash of the elements of the votation
+    uint256 vote = uint256(
+      sha256(
+        abi.encodePacked(
+      _blockHash,
+      _epoch,
+      _drMerkleRoot,
+      _tallyMerkleRoot,
+      _previousVote)));
+    if (voteInfo[vote].numberOfVotes == 0) {
+      // Add the vote to candidates
+      candidates.push(vote);
+      // Mapping the vote into its hashes
+      voteInfo[vote].voteHashes.blockHash = _blockHash;
+      voteInfo[vote].voteHashes.drMerkleRoot = _drMerkleRoot;
+      voteInfo[vote].voteHashes.tallyMerkleRoot = _tallyMerkleRoot;
+      voteInfo[vote].voteHashes.previousVote = _previousVote;
+    }
+
+    // Sum one vote
+    voteInfo[vote].numberOfVotes += 1;
+    // Check if there is a tie
+    if (vote != winnerVote) {
+      if (voteInfo[vote].numberOfVotes == voteInfo[winnerVote].numberOfVotes) {
+        emit Tie("there is been a tie");
+        tiedVote = vote;
+      }
+      // Set as new winner if it has more votes
+      if (voteInfo[vote].numberOfVotes > voteInfo[winnerVote].numberOfVotes) {
+        winnerVote = vote;
+        winnerId = _blockHash;
+        winnerEpoch = _epoch;
+        winnerDrMerkleRoot = _drMerkleRoot;
+        winnerTallyMerkleRoot = _tallyMerkleRoot;
+    }
+
+    }
+
+    return bytes32(vote);
+
+  }
+
+  /// @dev Retrieve the requests-only merkle root hash that was reported for a specific block header.
+  /// @param _blockHash Hash of the block header
+  /// @return Requests-only merkle root hash in the block header.
+  function readDrMerkleRoot(uint256 _blockHash)
+    public
+    view
+    blockExists(_blockHash)
+  returns(uint256 drMerkleRoot)
+    {
+    drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
+  }
+
+  /// @dev Retrieve the tallies-only merkle root hash that was reported for a specific block header.
+  /// @param _blockHash Hash of the block header
+  /// tallies-only merkle root hash in the block header.
+  function readTallyMerkleRoot(uint256 _blockHash)
+    public
+    view
+    blockExists(_blockHash)
+  returns(uint256 tallyMerkleRoot)
+  {
+    tallyMerkleRoot = blocks[_blockHash].tallyHashMerkleRoot;
+  }
+
+  /// @dev Read the beacon of the last block inserted
+  /// @return bytes to be signed by bridge nodes
+  function getLastBeacon()
+    public
+    view
+  returns(bytes memory)
+  {
+    return abi.encodePacked(lastBlock.blockHash, lastBlock.epoch);
+  }
+
+/// @dev Verifies the validity of a PoI against the DR merkle root
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
+  /// @param _blockHash the blockHash
+  /// @param _index the index in the merkle tree of the element to verify
+  /// @param _element the leaf to be verified
+  /// @return true or false depending the validity
+  function verifyDrPoi(
+    uint256[] memory _poi,
+    uint256 _blockHash,
+    uint256 _index,
+    uint256 _element)
+  public
+  view
+  blockExists(_blockHash)
+  finalizedEpoch(currentEpoch)
+  returns(bool)
+  {
+    uint256 drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
+    return(verifyPoi(
+      _poi,
+      drMerkleRoot,
+      _index,
+      _element));
+  }
+
+  /// @dev Verifies the validity of a PoI against the tally merkle root
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
+  /// @param _blockHash the blockHash
+  /// @param _index the index in the merkle tree of the element to verify
+  /// @param _element the element
+  /// @return true or false depending the validity
+  function verifyTallyPoi(
+    uint256[] memory _poi,
+    uint256 _blockHash,
+    uint256 _index,
+    uint256 _element)
+  public
+  view
+  blockExists(_blockHash)
+  returns(bool)
+  {
+    uint256 tallyMerkleRoot = blocks[_blockHash].tallyHashMerkleRoot;
+    return(verifyPoi(
+      _poi,
+      tallyMerkleRoot,
+      _index,
+      _element));
+
+  }
+
+  /// @dev Post new block into the block relay
+  /// @param _blockHash Hash of the block headerPost
+  /// @param _epoch Witnet epoch to which the block belongs to
+  /// @param _drMerkleRoot Merkle root belonging to the data requests
+  /// @param _tallyMerkleRoot Merkle root belonging to the tallies
+  function postNewBlock(
+    uint256 _vote,
+    uint256 _blockHash,
+    uint256 _epoch,
+    uint256 _drMerkleRoot,
+    uint256 _tallyMerkleRoot,
+    uint256 _previousVote)
+    private
+    blockDoesNotExist(_blockHash)
+  {
+    if (3*voteInfo[winnerVote].numberOfVotes < 2*activeIdentities) {
+      epochFinalizedBlock[_epoch].status = "Pending";
+      // Set the winner values to 0
+      winnerVote = 0;
+      winnerId = 0;
+      winnerEpoch = 0;
+      winnerDrMerkleRoot = 0;
+      winnerTallyMerkleRoot = 0;
+    } else {
+      // Map the epoch to the vote's Hashes
+      epochFinalizedBlock[_epoch].status = "Finalized";
+      epochFinalizedBlock[_epoch].blockHash = voteInfo[_vote].voteHashes.blockHash;
+      blocks[_blockHash].drHashMerkleRoot = _drMerkleRoot;
+      blocks[_blockHash].tallyHashMerkleRoot = _tallyMerkleRoot;
+      blocks[_blockHash].previousVote = _previousVote;
+      // Check if the status of the previous block is Pending and so it needs to be finalized
+      if (keccak256(abi.encodePacked((epochFinalizedBlock[_epoch-1].status))) == keccak256(abi.encodePacked(("Pending")))) {
+        uint x;
+        // Select the last Finalized epoch
+        for (uint i; i>=0; i++) {
+          if (keccak256(abi.encodePacked(epochFinalizedBlock[_epoch-i-1].status)) != keccak256(abi.encodePacked(("Finalized")))) {
+            x = i;
+            uint256 previousFinalVote;
+            // Finalize the previous epochs with the corresponding previous votes and hashes
+            previousFinalVote = blocks[epochFinalizedBlock[_epoch-i].blockHash].previousVote;
+            epochFinalizedBlock[_epoch - i-1].blockHash = voteInfo[previousFinalVote].voteHashes.blockHash;
+            uint256 previousBlockHash = voteInfo[previousFinalVote].voteHashes.blockHash;
+            blocks[previousBlockHash].drHashMerkleRoot = voteInfo[previousFinalVote].voteHashes.drMerkleRoot;
+            blocks[previousBlockHash].tallyHashMerkleRoot = voteInfo[previousFinalVote].voteHashes.tallyMerkleRoot;
+            // Set the previous status to Finalized
+            epochFinalizedBlock[_epoch-i-1].status = "Finalized";
+          } else if (keccak256(abi.encodePacked((epochFinalizedBlock[_epoch-i-1].status))) == keccak256(abi.encodePacked(("Finalized")))) {
+            break;
+          }
+        }
+        // Post each block as last beacon, from the oldest to the newest
+        for (uint j; j <= x-1; j++) {
+          lastBlock.blockHash = epochFinalizedBlock[_epoch - x + j].blockHash;
+          lastBlock.epoch = _epoch - x + j;
+        }
+       }
+       // Post the last block
+      lastBlock.blockHash = _blockHash;
+      lastBlock.epoch = _epoch;
+
+    // Set the winner values equal 0
+      winnerId = 0;
+      winnerVote = 0;
+      winnerId = 0;
+      winnerEpoch = 0;
+      winnerDrMerkleRoot = 0;
+      winnerTallyMerkleRoot = 0;
+      // Delete the condidates array so its empty for next epoch
+      for (uint i = 0; i <= candidates.length - 1; i++) {
+        delete voteInfo[candidates[i]].voteHashes;}
+      delete candidates;
+  }
+  }
+
+  /// @dev Verifies the validity of a PoI
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
+  /// @param _root the merkle root
+  /// @param _index the index in the merkle tree of the element to verify
+  /// @param _element the leaf to be verified
+  /// @return true or false depending the validity
+  function verifyPoi(
+    uint256[] memory _poi,
+    uint256 _root,
+    uint256 _index,
+    uint256 _element)
+  private pure returns(bool)
+  {
+    uint256 tree = _element;
+    uint256 index = _index;
+    // We want to prove that the hash of the _poi and the _element is equal to _root
+    // For knowing if concatenate to the left or the right we check the parity of the the index
+    for (uint i = 0; i<_poi.length; i++) {
+      if (index%2 == 0) {
+        tree = uint256(sha256(abi.encodePacked(tree, _poi[i])));
+      } else {
+        tree = uint256(sha256(abi.encodePacked(_poi[i], tree)));
+      }
+      index = index>>1;
+    }
+    return _root==tree;
+  }
+
+}

--- a/contracts/NewBlockRelay.sol
+++ b/contracts/NewBlockRelay.sol
@@ -16,7 +16,7 @@ contract NewBlockRelay is WitnetBridgeInterface {
     uint256 drHashMerkleRoot;
     // hash of the merkle root of the tallies in Witnet
     uint256 tallyHashMerkleRoot;
-    // Vote for the previous block hash
+    // Hash of the vote that this block extends
     uint256 previousVote;
   }
 
@@ -37,6 +37,7 @@ contract NewBlockRelay is WitnetBridgeInterface {
   }
 
   struct VoteInfo {
+    // Information of Block Candidate
     uint256 numberOfVotes;
     Hashes voteHashes;
   }
@@ -46,10 +47,10 @@ contract NewBlockRelay is WitnetBridgeInterface {
 
   // Initializes the block with the maximum number of votes
   uint256 winnerVote;
-  uint256 winnerId = 0;
-  uint256 winnerDrMerkleRoot = 0;
-  uint256 winnerTallyMerkleRoot = 0;
-  uint256 winnerEpoch = 0;
+  uint256 winnerId;
+  uint256 winnerDrMerkleRoot;
+  uint256 winnerTallyMerkleRoot;
+  uint256 winnerEpoch;
 
   // Needed for the constructor
   uint256 witnetGenesis;
@@ -94,7 +95,7 @@ contract NewBlockRelay is WitnetBridgeInterface {
   }
 
    //  Ensures that neither Poi nor PoE are allowed if the epoch is pending
-  modifier finalizedEpoch2(uint256 _epoch){
+  modifier finalizedEpoch(uint256 _epoch){
     require(
       (epochFinalizedBlock[_epoch] != 0),
       "The block has not been finalized");
@@ -171,7 +172,7 @@ contract NewBlockRelay is WitnetBridgeInterface {
   public
   view
   blockExists(_blockHash)
-  finalizedEpoch2(currentEpoch)
+  finalizedEpoch(currentEpoch)
   returns(bool)
   {
     uint256 drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
@@ -338,6 +339,9 @@ contract NewBlockRelay is WitnetBridgeInterface {
     // Post the last block
     lastBlock.blockHash = _blockHash;
     lastBlock.epoch = _epoch;
+
+    // Update the ABS activity once finalized
+    uint256 activeIdentities = uint256(abs.activeIdentities);
 
     // Delete the condidates array so its empty for next epoch
     for (uint i = 0; i <= candidates.length - 1; i++) {

--- a/migrations/5_deploy_new_block_relay.js
+++ b/migrations/5_deploy_new_block_relay.js
@@ -1,0 +1,6 @@
+var NewBlockRelay = artifacts.require("NewBlockRelay")
+
+module.exports = function (deployer, network) {
+  console.log(`> Migrating NewBlockRelay into ${network} network`)
+  deployer.deploy(NewBlockRelay, 1568559600, 90, 0)
+}

--- a/test/helpers/NewBRTestHelper.sol
+++ b/test/helpers/NewBRTestHelper.sol
@@ -6,8 +6,7 @@ import "../../contracts/ActiveBridgeSetLib.sol";
 
 /**
  * @title Test Helper for the new block Relay contract
- * @dev The aim of this contract is:
- * 1. Raise the visibility modifier of new block relay contract functions for testing purposes
+ * @dev The aim of this contract is to raise the visibility modifier of new block relay contract functions for testing purposes
  * @author Witnet Foundation
  */
 
@@ -81,7 +80,7 @@ contract NewBRTestHelper is NewBlockRelay {
     return candidates.length;
   }
 
-  // Checks if the cuurentEpoch - 2 in pending
+  // Checks if the epoch is finalized
   function checkEpochFinalized(uint256 _epoch) public returns (bool) {
     if (epochFinalizedBlock[_epoch] != 0) {
       return true;

--- a/test/helpers/NewBRTestHelper.sol
+++ b/test/helpers/NewBRTestHelper.sol
@@ -1,0 +1,107 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../../contracts/NewBlockRelay.sol";
+import "../../contracts/ActiveBridgeSetLib.sol";
+
+/**
+ * @title Test Helper for the new block Relay contract
+ * @dev The aim of this contract is:
+ * 1. Raise the visibility modifier of new block relay contract functions for testing purposes
+ * @author Witnet Foundation
+ */
+
+
+contract NewBRTestHelper is NewBlockRelay {
+  NewBlockRelay br;
+  uint256 timestamp;
+  uint256 witnetGenesis;
+  uint256 firstBlock;
+
+  using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
+
+  constructor (uint256 _witnetGenesis, uint256 _epochSeconds, uint256 _firstBlock)
+  NewBlockRelay(_witnetGenesis, _epochSeconds, _firstBlock) public {}
+
+  // Pushes the activity in the ABS
+  function pushActivity(uint256 _blockNumber) public {
+    address _address = msg.sender;
+    abs.pushActivity(_address, _blockNumber);
+  }
+
+  // Updates the currentEpoch
+  function updateEpoch() public view returns (uint256) {
+    return currentEpoch;
+  }
+
+  // Sets the current epoch to be the next
+  function nextEpoch() public {
+    currentEpoch = currentEpoch + 1;
+  }
+
+  // Sets the currentEpoch
+  function setEpoch(uint256 _epoch) public returns (uint256) {
+    currentEpoch = _epoch;
+  }
+
+  // Sets the number of members in the ABS
+  function setAbsIdentitiesNumber(uint256 _identitiesNumber) public returns (uint256) {
+    activeIdentities = _identitiesNumber;
+  }
+
+  // Sets the previous epoch as finalized
+  function setPreviousEpochFinalized() public {
+    epochFinalizedBlock[currentEpoch - 2].status = "Finalized";
+  }
+
+  // Gets the vote with the poposeBlock inputs
+  function getVote(
+    uint256 _blockHash,
+    uint256 _epoch,
+    uint256 _drMerkleRoot,
+    uint256 _tallyMerkleRoot,
+    uint256 _previousVote) public returns(uint256)
+    {
+    uint256 vote = uint256(
+      sha256(
+        abi.encodePacked(
+      _blockHash,
+      _epoch,
+      _drMerkleRoot,
+      _tallyMerkleRoot,
+      _previousVote)));
+
+    return vote;
+
+  }
+
+  // Gets the blockHash of a vote finalized in a specific epoch
+  function getBlockHash(uint256 _epoch) public  returns (uint256) {
+    uint256 blockHash = epochFinalizedBlock[_epoch].blockHash;
+    return blockHash;
+  }
+
+  // Gets the length of the candidates array
+  function getCandidatesLength() public view returns (uint256) {
+    return candidates.length;
+  }
+
+  // Checks if the cuurentEpoch - 2 in pending
+  function checkStatusPending() public returns (bool) {
+    string memory pending = "Pending";
+    //emit EpochStatus(epochStatus[currentEpoch-2])
+    if (keccak256(abi.encodePacked((epochFinalizedBlock[currentEpoch - 2].status))) == keccak256(abi.encodePacked((pending)))) {
+      return true;
+    }
+  }
+
+  // Checks if the cuurentEpoch - 2 in pending
+  function checkStatusFinalized() public returns (bool) {
+    string memory finalized = "Finalized";
+    //emit EpochStatus(epochStatus[currentEpoch-2])
+    if (keccak256(abi.encodePacked((epochFinalizedBlock[currentEpoch - 2].status))) == keccak256(abi.encodePacked((finalized)))) {
+      return true;
+    }
+  }
+
+}

--- a/test/helpers/NewBRTestHelper.sol
+++ b/test/helpers/NewBRTestHelper.sol
@@ -49,11 +49,6 @@ contract NewBRTestHelper is NewBlockRelay {
     activeIdentities = _identitiesNumber;
   }
 
-  // Sets the previous epoch as finalized
-  function setPreviousEpochFinalized() public {
-    epochFinalizedBlock[currentEpoch - 2].status = "Finalized";
-  }
-
   // Gets the vote with the poposeBlock inputs
   function getVote(
     uint256 _blockHash,
@@ -77,7 +72,7 @@ contract NewBRTestHelper is NewBlockRelay {
 
   // Gets the blockHash of a vote finalized in a specific epoch
   function getBlockHash(uint256 _epoch) public  returns (uint256) {
-    uint256 blockHash = epochFinalizedBlock[_epoch].blockHash;
+    uint256 blockHash = epochFinalizedBlock[_epoch];
     return blockHash;
   }
 
@@ -87,19 +82,8 @@ contract NewBRTestHelper is NewBlockRelay {
   }
 
   // Checks if the cuurentEpoch - 2 in pending
-  function checkStatusPending() public returns (bool) {
-    string memory pending = "Pending";
-    //emit EpochStatus(epochStatus[currentEpoch-2])
-    if (keccak256(abi.encodePacked((epochFinalizedBlock[currentEpoch - 2].status))) == keccak256(abi.encodePacked((pending)))) {
-      return true;
-    }
-  }
-
-  // Checks if the cuurentEpoch - 2 in pending
-  function checkStatusFinalized() public returns (bool) {
-    string memory finalized = "Finalized";
-    //emit EpochStatus(epochStatus[currentEpoch-2])
-    if (keccak256(abi.encodePacked((epochFinalizedBlock[currentEpoch - 2].status))) == keccak256(abi.encodePacked((finalized)))) {
+  function checkEpochFinalized(uint256 _epoch) public returns (bool) {
+    if (epochFinalizedBlock[_epoch] != 0) {
       return true;
     }
   }

--- a/test/new_block_relay.js
+++ b/test/new_block_relay.js
@@ -1,0 +1,411 @@
+const NewBlockRelay = artifacts.require("NewBlockRelay")
+const sha = require("js-sha256")
+const NewBRTestHelper = artifacts.require("NewBRTestHelper")
+const truffleAssert = require("truffle-assertions")
+contract("New Block Relay", accounts => {
+  describe("New block relay test suite", () => {
+    let contest
+    beforeEach(async () => {
+      await NewBlockRelay.new(1568559600, 90, 0, {
+        from: accounts[0],
+      })
+      contest = await NewBRTestHelper.new(1568559600, 90, 0)
+    })
+    it("should propose and post a new block", async () => {
+      // The blockhash we want to propose
+      const blockHash = "0x" + sha.sha256("the vote to propose")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      let epoch = await contest.updateEpoch.call()
+      contest.setPreviousEpochFinalized()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the ABS to just one member
+      await contest.setAbsIdentitiesNumber(1)
+      // Propose the vote to the Block Relay
+      const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      // Get the vote proposed as the concatenation of the elemetns of the proposeBlock
+      const Vote = await contest.getVote.call(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Wait unitl the next epoch to get the final result
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose another block in the next epoch so the previous one is finalized
+      await contest.proposeBlock(0, epoch - 1, 0, 0, Vote)
+      // Concatenation of the blockhash and the epoch-1 to check later if it's equal to the last beacon
+      const concatenated = web3.utils.hexToBytes(blockHash).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 2), 64
+          )
+        )
+      )
+      // Should be equal the last beacon to vote
+      const beacon = await contest.getLastBeacon.call()
+      assert.equal(beacon, web3.utils.bytesToHex(concatenated))
+    })
+
+    it("should propose 3 blocks for the same epoch and post the winner", async () => {
+      // The are to votes: blockHash1, voted once and blockHash2 voted twice.
+      // It should win blockHash2 and so be posted in the Block Relay
+      const blockHash1 = "0x" + sha.sha256("first vote")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Propose vote1 to the Block Relay
+      const tx1 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx1)
+      // Propose vote2 to the Block Relay
+      contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Propose for the second time vote2
+      contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      const Vote2 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Wait unitl the next epoch so to get the final result
+      await contest.nextEpoch()
+      // Propose another block in the next epoch so the previous one is finalized
+      await contest.proposeBlock(0, epoch, 0, 0, Vote2)
+      // Concatenation of the blockhash and the epoch to check later if it's equal to the last beacon
+      const concatenated = web3.utils.hexToBytes(blockHash2).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 1), 64
+          )
+        )
+      )
+      // Should be equal the last beacon to vote2, since is the most voted
+      const beacon = await contest.getLastBeacon.call()
+      assert.equal(beacon, web3.utils.bytesToHex(concatenated))
+    })
+
+    it("should post a new block when getting consensus", async () => {
+      // the blockhash we want to propose
+      const blockHash1 = "0x" + sha.sha256("the vote to propose")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the number of members of the ABS to 3
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose the vote 3 times to the Block Relay
+      const tx = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      const tx2 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx2)
+      const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx3)
+      // Get the vote proposed as the concatenation of the elemetns of the proposeBlock
+      const Vote = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Wait unitl the next epoch
+      await contest.nextEpoch()
+      // Propose another block in the new epoch and so post the previous one
+      contest.proposeBlock(blockHash2, epoch, drMerkleRoot, tallyMerkleRoot, Vote)
+      // Concatenation of the blockhash and the epoch -1 to check later if it's equal to the last beacon
+      const concatenated = web3.utils.hexToBytes(blockHash1).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 1), 64
+          )
+        )
+      )
+      // Should be equal the last beacon
+      const beacon = await contest.getLastBeacon.call()
+      assert.equal(beacon, web3.utils.bytesToHex(concatenated))
+    })
+
+    it("should set the previos block to pending when not achieved 2/3 of the ABS", async () => {
+      // the blockhash we want to propose
+      const blockHash = "0x" + sha.sha256("the vote to propose")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the abs to 3 identities
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose the vote to the Block Relay
+      const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      // Wait unitl the next epoch to get the final result
+      await contest.nextEpoch()
+      // Propose another block in the next epoch so the previous one is finalized
+      await contest.proposeBlock(0, epoch, 0, 0, 0)
+      // Check the status of epoch -2
+      const epochStatus = await contest.checkStatusPending.call()
+      assert.equal(epochStatus, true)
+    })
+
+    it("should revert because the block proposed is not for a valid epoch", async () => {
+      const vote = "0x" + sha.sha256("vote proposed")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Should revert because proposing for the current epoch
+      await truffleAssert.reverts(contest.proposeBlock(vote, epoch, drMerkleRoot, tallyMerkleRoot, 0),
+        "Proposing a block for a non valid epoch")
+    })
+
+    it("should revert because not in the ABS", async () => {
+      const vote = "0x" + sha.sha256("vote proposed")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+      // should revert beacause not a memeber of the ABS
+      await truffleAssert.reverts(contest.proposeBlock(vote, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0),
+        "Not a member of the abs")
+    })
+
+    it("should check a vote that is a candidates is deleted when posted", async () => {
+      // the blockhash we want to propose
+      const blockHash = "0x" + sha.sha256("the vote to propose")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      let setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      let epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Propose the vote to the Block Relay
+      const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      // Fix the timestamp to be one epoch later
+      setEpoch = contest.setEpoch(89160)
+      await waitForHash(setEpoch)
+      epoch = await contest.updateEpoch.call()
+      // Propose another block in the next epoch so the previous one is finalized
+      await contest.proposeBlock(0, epoch - 1, 0, 0, 0)
+      // The candidates array
+      const candidate = await contest.getCandidatesLength.call()
+      // Assert there is just one candidate since the first is been canceled when posted
+      assert.equal(1, candidate)
+    })
+
+    it("should finalize a block and the previous epochs when Pending", async () => {
+      // The idea is that after two epoch with no consesus, when in epoch n the consensus is achived then
+      // epochs n-1 and n-2 are finalized as well
+      const blockHash0 = "0x" + sha.sha256("null vote")
+      const blockHash1 = "0x" + sha.sha256("first vote")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const blockHash3 = "0x" + sha.sha256("third vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      let epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the ABS to 3 members
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose blockHash0 to he Block Relay 3 times
+      const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      const Vote = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash1 to the Block Relay
+      const tx2 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      await waitForHash(tx2)
+      const Vote1 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash2 to the Block Relay
+      const tx3 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      await waitForHash(tx3)
+      const Vote2 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose 3 times blockHash3 to the Block Relay
+      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      const Vote3 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose a random vote just to finalize previous epochs
+      await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      // Now we want to check that
+      const epochStatus = await contest.checkStatusFinalized.call()
+      assert.equal(epochStatus, true)
+    })
+
+    it("should confirm a vote is been finalized", async () => {
+      // The idea is that after two epoch with no consesus, when in epoch n the consensus
+      // is achived epochs n-1 and n-2 are finalized as well
+      const blockHash0 = "0x" + sha.sha256("null vote")
+      const blockHash1 = "0x" + sha.sha256("first vote")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const blockHash3 = "0x" + sha.sha256("third vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      let epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the ABS to 3 members
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose blockHash0 3 times to the Block Relay
+      const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      const tx1 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx1)
+      const tx2 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx2)
+      const Vote1 = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash1 to the Block Relay
+      const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      await waitForHash(tx3)
+      const Vote2 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash2 to the Block Relay
+      const tx7 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      await waitForHash(tx7)
+      const Vote3 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose 3 times blockHash3 to the Block Relay
+      const tx4 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx4)
+      const tx5 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx5)
+      const tx6 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx6)
+      const Vote4 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose a random vote just to finalize previous epochs
+      await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote4)
+      // Check the blockHash for epoch 89161 is the right one
+      let blockHash = await contest.getBlockHash.call(89161)
+      blockHash = "0x" + blockHash.toString(16)
+      const concatenated = web3.utils.hexToBytes(blockHash).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 2), 64
+          )
+        )
+      )
+      // Should be equal the last beacon to vote
+      const beacon = await contest.getLastBeacon.call()
+      assert.equal(beacon, web3.utils.bytesToHex(concatenated))
+    })
+
+    it("should confirm that currentEpoch - 3 is been posted", async () => {
+      // The idea is that after two epoch with no consesus, when in epoch n the
+      // consensus is achived then previpus epochs that were pending are finalized as well
+      const blockHash0 = "0x" + sha.sha256("null vote")
+      const blockHash1 = "0x" + sha.sha256("first vote")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const blockHash3 = "0x" + sha.sha256("third vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      let epoch = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the ABS to 3 members
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose blockHash0 3 times to the Block Relay
+      const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      const tx1 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx1)
+      const tx2 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx2)
+      const Vote1 = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Wait for the next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash1 to the Block Relay
+      const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      await waitForHash(tx3)
+      const Vote2 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose blockHash2 to the BlockRelay
+      const tx7 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      await waitForHash(tx7)
+      const Vote3 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose 3 times blockHash3 to the Block Relay
+      const tx4 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx4)
+      const tx5 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx5)
+      const tx6 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      await waitForHash(tx6)
+      const Vote4 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      epoch = await contest.updateEpoch.call()
+      // Propose a random vote just to finalize previous epochs
+      await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote4)
+      // Get the blockHash finalized for the epoch 89160
+      let blockHash = await contest.getBlockHash.call(89160)
+      blockHash = "0x" + blockHash.toString(16)
+      const concatenated = web3.utils.hexToBytes(blockHash).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 3), 64
+          )
+        )
+      )
+      const concatenated2 = web3.utils.hexToBytes(blockHash2).concat(
+        web3.utils.hexToBytes(
+          web3.utils.padLeft(
+            web3.utils.toHex(epoch - 3), 64
+          )
+        )
+      )
+      // The block hash in epoch 89160 should be equal to blockHash2
+      assert.equal(web3.utils.bytesToHex(concatenated), web3.utils.bytesToHex(concatenated2))
+    })
+  })
+})
+const waitForHash = txQ =>
+  new Promise((resolve, reject) =>
+    txQ.on("transactionHash", resolve).catch(reject)
+  )

--- a/test/new_block_relay.js
+++ b/test/new_block_relay.js
@@ -20,7 +20,6 @@ contract("New Block Relay", accounts => {
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       let epoch = await contest.updateEpoch.call()
-      contest.setPreviousEpochFinalized()
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the ABS to just one member
@@ -126,7 +125,7 @@ contract("New Block Relay", accounts => {
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
     })
 
-    it("should set the previos block to pending when not achieved 2/3 of the ABS", async () => {
+    it("should not finalized a block when not achieved 2/3 of the ABS", async () => {
       // the blockhash we want to propose
       const blockHash = "0x" + sha.sha256("the vote to propose")
       const drMerkleRoot = 1
@@ -147,8 +146,8 @@ contract("New Block Relay", accounts => {
       // Propose another block in the next epoch so the previous one is finalized
       await contest.proposeBlock(0, epoch, 0, 0, 0)
       // Check the status of epoch -2
-      const epochStatus = await contest.checkStatusPending.call()
-      assert.equal(epochStatus, true)
+      const epochStatus = await contest.checkEpochFinalized.call(epoch)
+      assert.equal(epochStatus, false)
     })
 
     it("should revert because the block proposed is not for a valid epoch", async () => {
@@ -179,7 +178,7 @@ contract("New Block Relay", accounts => {
         "Not a member of the abs")
     })
 
-    it("should check a vote that is a candidates is deleted when posted", async () => {
+    it("should check a candidates is deleted when posted", async () => {
       // the blockhash we want to propose
       const blockHash = "0x" + sha.sha256("the vote to propose")
       const drMerkleRoot = 1
@@ -205,61 +204,7 @@ contract("New Block Relay", accounts => {
       assert.equal(1, candidate)
     })
 
-    it("should finalize a block and the previous epochs when Pending", async () => {
-      // The idea is that after two epoch with no consesus, when in epoch n the consensus is achived then
-      // epochs n-1 and n-2 are finalized as well
-      const blockHash0 = "0x" + sha.sha256("null vote")
-      const blockHash1 = "0x" + sha.sha256("first vote")
-      const blockHash2 = "0x" + sha.sha256("second vote")
-      const blockHash3 = "0x" + sha.sha256("third vote")
-      const drMerkleRoot = 1
-      const tallyMerkleRoot = 1
-      // Fix the timestamp in witnet to be 89159
-      const setEpoch = contest.setEpoch(89159)
-      await waitForHash(setEpoch)
-      let epoch = await contest.updateEpoch.call()
-      // Update the ABS to be included
-      await contest.pushActivity(1)
-      // Set the ABS to 3 members
-      await contest.setAbsIdentitiesNumber(3)
-      // Propose blockHash0 to he Block Relay 3 times
-      const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await waitForHash(tx)
-      contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      const Vote = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
-      // Propose blockHash1 to the Block Relay
-      const tx2 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote)
-      await waitForHash(tx2)
-      const Vote1 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
-      // Propose blockHash2 to the Block Relay
-      const tx3 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
-      await waitForHash(tx3)
-      const Vote2 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
-      // Propose 3 times blockHash3 to the Block Relay
-      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      const Vote3 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
-      // Propose a random vote just to finalize previous epochs
-      await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      // Now we want to check that
-      const epochStatus = await contest.checkStatusFinalized.call()
-      assert.equal(epochStatus, true)
-    })
-
-    it("should confirm a vote is been finalized", async () => {
+    it("should confirm blocks are been finalized", async () => {
       // The idea is that after two epoch with no consesus, when in epoch n the consensus
       // is achived epochs n-1 and n-2 are finalized as well
       const blockHash0 = "0x" + sha.sha256("null vote")
@@ -313,24 +258,23 @@ contract("New Block Relay", accounts => {
       epoch = await contest.updateEpoch.call()
       // Propose a random vote just to finalize previous epochs
       await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote4)
+      // Check the blockHash for epoch 89159 is the right one
+      let FinalBlockHash1 = await contest.getBlockHash.call(89159)
+      FinalBlockHash1 = "0x" + FinalBlockHash1.toString(16)
+      assert.equal(FinalBlockHash1, blockHash1)
+      // Check the blockHash for epoch 89160 is the right one
+      let FinalBlockHash2 = await contest.getBlockHash.call(89160)
+      FinalBlockHash2 = "0x" + FinalBlockHash2.toString(16)
+      assert.equal(FinalBlockHash2, blockHash2)
       // Check the blockHash for epoch 89161 is the right one
-      let blockHash = await contest.getBlockHash.call(89161)
-      blockHash = "0x" + blockHash.toString(16)
-      const concatenated = web3.utils.hexToBytes(blockHash).concat(
-        web3.utils.hexToBytes(
-          web3.utils.padLeft(
-            web3.utils.toHex(epoch - 2), 64
-          )
-        )
-      )
-      // Should be equal the last beacon to vote
-      const beacon = await contest.getLastBeacon.call()
-      assert.equal(beacon, web3.utils.bytesToHex(concatenated))
+      let FinalBlockHash3 = await contest.getBlockHash.call(89161)
+      FinalBlockHash3 = "0x" + FinalBlockHash3.toString(16)
+      assert.equal(FinalBlockHash3, blockHash3)
     })
 
-    it("should confirm that currentEpoch - 3 is been posted", async () => {
-      // The idea is that after two epoch with no consesus, when in epoch n the
-      // consensus is achived then previpus epochs that were pending are finalized as well
+    it("should finalize a block and the previous epochs when Pending", async () => {
+      // The idea is that after two epoch with no consesus, when in epoch4 - 1 the consensus is achived then
+      // epoch1 - 1, epoch2 - 1 and epoch3 - 1 are finalized as well
       const blockHash0 = "0x" + sha.sha256("null vote")
       const blockHash1 = "0x" + sha.sha256("first vote")
       const blockHash2 = "0x" + sha.sha256("second vote")
@@ -340,68 +284,96 @@ contract("New Block Relay", accounts => {
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
-      let epoch = await contest.updateEpoch.call()
+      const epoch1 = await contest.updateEpoch.call()
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the ABS to 3 members
       await contest.setAbsIdentitiesNumber(3)
-      // Propose blockHash0 3 times to the Block Relay
-      const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Propose blockHash0 to he Block Relay 3 times
+      const tx = contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
-      const tx1 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await waitForHash(tx1)
-      const tx2 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await waitForHash(tx2)
-      const Vote1 = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      // Wait for the next epoch
+      contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      const Vote = await contest.getVote.call(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
+      const epoch2 = await contest.updateEpoch.call()
       // Propose blockHash1 to the Block Relay
-      const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      const tx2 = contest.proposeBlock(blockHash1, epoch2 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      await waitForHash(tx2)
+      const Vote1 = await contest.getVote.call(blockHash1, epoch2 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      const epoch3 = await contest.updateEpoch.call()
+      // Propose blockHash2 to the Block Relay
+      const tx3 = contest.proposeBlock(blockHash2, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
       await waitForHash(tx3)
-      const Vote2 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+      const Vote2 = await contest.getVote.call(blockHash2, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
       // Wait for next epoch
       await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
-      // Propose blockHash2 to the BlockRelay
-      const tx7 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      await waitForHash(tx7)
-      const Vote3 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
+      const epoch4 = await contest.updateEpoch.call()
       // Propose 3 times blockHash3 to the Block Relay
-      const tx4 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      await waitForHash(tx4)
-      const tx5 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      await waitForHash(tx5)
-      const tx6 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      await waitForHash(tx6)
-      const Vote4 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+      const Vote3 = await contest.getVote.call(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
       // Wait for next epoch
       await contest.nextEpoch()
-      epoch = await contest.updateEpoch.call()
+      const epoch5 = await contest.updateEpoch.call()
       // Propose a random vote just to finalize previous epochs
-      await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote4)
-      // Get the blockHash finalized for the epoch 89160
-      let blockHash = await contest.getBlockHash.call(89160)
-      blockHash = "0x" + blockHash.toString(16)
-      const concatenated = web3.utils.hexToBytes(blockHash).concat(
-        web3.utils.hexToBytes(
-          web3.utils.padLeft(
-            web3.utils.toHex(epoch - 3), 64
-          )
-        )
-      )
-      const concatenated2 = web3.utils.hexToBytes(blockHash2).concat(
-        web3.utils.hexToBytes(
-          web3.utils.padLeft(
-            web3.utils.toHex(epoch - 3), 64
-          )
-        )
-      )
-      // The block hash in epoch 89160 should be equal to blockHash2
-      assert.equal(web3.utils.bytesToHex(concatenated), web3.utils.bytesToHex(concatenated2))
+      await contest.proposeBlock(blockHash2, epoch5 - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      // Now we want to check that
+      let epochStatus = await contest.checkEpochFinalized.call(epoch4 - 1)
+      assert.equal(epochStatus, true)
+      epochStatus = await contest.checkEpochFinalized.call(epoch3 - 1)
+      assert.equal(epochStatus, true)
+      epochStatus = await contest.checkEpochFinalized.call(epoch2 - 1)
+      assert.equal(epochStatus, true)
+      epochStatus = await contest.checkEpochFinalized.call(epoch1 - 1)
+      assert.equal(epochStatus, true)
+    })
+
+    it("should finalize a block even if previous epochs have no blocks proposed", async () => {
+      // Block Hashes to propose
+      const blockHash0 = "0x" + sha.sha256("null vote")
+      const blockHash1 = "0x" + sha.sha256("first vote")
+      const blockHash2 = "0x" + sha.sha256("second vote")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch1 = await contest.updateEpoch.call()
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+      // Set the ABS to 3 members
+      await contest.setAbsIdentitiesNumber(3)
+      // Propose blockHash0 to he Block Relay
+      const tx = contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+      const Vote = await contest.getVote.call(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Set two epochs later with no blocks proposed in epoch2
+      await contest.nextEpoch()
+      const epoch2 = await contest.updateEpoch.call()
+      await contest.nextEpoch()
+      const epoch3 = await contest.updateEpoch.call()
+      // Propose 3 times blockHash3 to the Block Relay
+      contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      const Vote3 = await contest.getVote.call(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      // Wait for next epoch
+      await contest.nextEpoch()
+      const epoch4 = await contest.updateEpoch.call()
+      // Propose a random vote just to finalize previous epochs
+      await contest.proposeBlock(blockHash2, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+      // Now we want to check that
+      let epochStatus = await contest.checkEpochFinalized.call(epoch3 - 1)
+      assert.equal(epochStatus, true)
+      epochStatus = await contest.checkEpochFinalized.call(epoch1 - 1)
+      assert.equal(epochStatus, true)
+      // The epoch with no blocks proposed should not be finalized
+      epochStatus = await contest.checkEpochFinalized.call(epoch2 - 1)
+      assert.equal(epochStatus, false)
     })
   })
 })

--- a/test/new_block_relay.js
+++ b/test/new_block_relay.js
@@ -12,29 +12,33 @@ contract("New Block Relay", accounts => {
       contest = await NewBRTestHelper.new(1568559600, 90, 0)
     })
     it("should propose and post a new block", async () => {
-      // The blockhash we want to propose
+      // The blockHash we want to propose
       const blockHash = "0x" + sha.sha256("the vote to propose")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       let epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
-      // Set the ABS to just one member
-      await contest.setAbsIdentitiesNumber(1)
+
       // Propose the vote to the Block Relay
       const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
-      // Get the vote proposed as the concatenation of the elemetns of the proposeBlock
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote = await contest.getVote.call(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+
       // Wait unitl the next epoch to get the final result
       await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose another block in the next epoch so the previous one is finalized
       await contest.proposeBlock(0, epoch - 1, 0, 0, Vote)
-      // Concatenation of the blockhash and the epoch-1 to check later if it's equal to the last beacon
+
+      // Concatenation of the blockHash and the epoch-1 to check later if it's equal to the last beacon
       const concatenated = web3.utils.hexToBytes(blockHash).concat(
         web3.utils.hexToBytes(
           web3.utils.padLeft(
@@ -42,8 +46,10 @@ contract("New Block Relay", accounts => {
           )
         )
       )
-      // Should be equal the last beacon to vote
+      // Get last beacon
       const beacon = await contest.getLastBeacon.call()
+
+      // Should be equal the last beacon to vote
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
     })
 
@@ -54,25 +60,32 @@ contract("New Block Relay", accounts => {
       const blockHash2 = "0x" + sha.sha256("second vote")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
-      // Propose vote1 to the Block Relay
+
+      // Propose blockHash1 to the Block Relay
       const tx1 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx1)
-      // Propose vote2 to the Block Relay
+      // Propose blockHash2 to the Block Relay
       contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      // Propose for the second time vote2
+      // Propose for the second time blockHash2
       contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote2 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+
       // Wait unitl the next epoch so to get the final result
       await contest.nextEpoch()
+
       // Propose another block in the next epoch so the previous one is finalized
       await contest.proposeBlock(0, epoch, 0, 0, Vote2)
-      // Concatenation of the blockhash and the epoch to check later if it's equal to the last beacon
+
+      // Concatenation of the blockHash2 and the epoch to check later if it's equal to the last beacon
       const concatenated = web3.utils.hexToBytes(blockHash2).concat(
         web3.utils.hexToBytes(
           web3.utils.padLeft(
@@ -80,38 +93,46 @@ contract("New Block Relay", accounts => {
           )
         )
       )
-      // Should be equal the last beacon to vote2, since is the most voted
+      // Get last beacon
       const beacon = await contest.getLastBeacon.call()
+      // Last beacon should be equal to blockhash2, since is the most voted
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
     })
 
     it("should post a new block when getting consensus", async () => {
-      // the blockhash we want to propose
+      // It should finalized a block when a vote achieves 2/3 of the votes of the ABS
+      // Block's hashes we want to propose to the Block Relay
       const blockHash1 = "0x" + sha.sha256("the vote to propose")
       const blockHash2 = "0x" + sha.sha256("second vote")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the number of members of the ABS to 3
       await contest.setAbsIdentitiesNumber(3)
-      // Propose the vote 3 times to the Block Relay
+
+      // Propose blockHash1 3 times to the Block Relay
       const tx = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
       const tx2 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx2)
       const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx3)
-      // Get the vote proposed as the concatenation of the elemetns of the proposeBlock
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+
       // Wait unitl the next epoch
       await contest.nextEpoch()
+
       // Propose another block in the new epoch and so post the previous one
       contest.proposeBlock(blockHash2, epoch, drMerkleRoot, tallyMerkleRoot, Vote)
+
       // Concatenation of the blockhash and the epoch -1 to check later if it's equal to the last beacon
       const concatenated = web3.utils.hexToBytes(blockHash1).concat(
         web3.utils.hexToBytes(
@@ -120,107 +141,166 @@ contract("New Block Relay", accounts => {
           )
         )
       )
-      // Should be equal the last beacon
+      // Get last beacon
       const beacon = await contest.getLastBeacon.call()
+      // Should be equal the last beacon
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
     })
 
     it("should not finalized a block when not achieved 2/3 of the ABS", async () => {
-      // the blockhash we want to propose
+      // It shouldn't finalize a block if it has not achieved consensus
+      // Block's hashes we want to propose
       const blockHash = "0x" + sha.sha256("the vote to propose")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the abs to 3 identities
       await contest.setAbsIdentitiesNumber(3)
+
       // Propose the vote to the Block Relay
       const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
+
       // Wait unitl the next epoch to get the final result
       await contest.nextEpoch()
+
       // Propose another block in the next epoch so the previous one is finalized
       await contest.proposeBlock(0, epoch, 0, 0, 0)
+
       // Check the status of epoch -2
       const epochStatus = await contest.checkEpochFinalized.call(epoch)
       assert.equal(epochStatus, false)
     })
 
     it("should revert because the block proposed is not for a valid epoch", async () => {
-      const vote = "0x" + sha.sha256("vote proposed")
+      // It is only allowed to propose blocks for currentEpoch -1
+      // Block's hashes we want to propose
+      const blockHash = "0x" + sha.sha256("vote proposed")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
+
       // Should revert because proposing for the current epoch
-      await truffleAssert.reverts(contest.proposeBlock(vote, epoch, drMerkleRoot, tallyMerkleRoot, 0),
+      await truffleAssert.reverts(contest.proposeBlock(blockHash, epoch, drMerkleRoot, tallyMerkleRoot, 0),
+        "Proposing a block for a non valid epoch")
+      // Should revert because proposing for the current epoch - 2
+      await truffleAssert.reverts(contest.proposeBlock(blockHash, epoch - 2, drMerkleRoot, tallyMerkleRoot, 0),
         "Proposing a block for a non valid epoch")
     })
 
     it("should revert because not in the ABS", async () => {
-      const vote = "0x" + sha.sha256("vote proposed")
+      // It is not allowed to propose a block if not a member of the ABS
+      // Block's hashes we want to propose
+      const blockHash = "0x" + sha.sha256("vote proposed")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch = await contest.updateEpoch.call()
-      // should revert beacause not a memeber of the ABS
-      await truffleAssert.reverts(contest.proposeBlock(vote, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0),
+
+      // Should revert beacause not a member of the ABS
+      await truffleAssert.reverts(contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0),
         "Not a member of the abs")
     })
 
-    it("should check a candidates is deleted when posted", async () => {
-      // the blockhash we want to propose
+    it("should revert when proposing a blockHash already finalized", async () => {
+      // It is not allowed to propose a block's hash if it's already a finalized block
+      // Block's hashes we want to propose
+      const blockHash = "0x" + sha.sha256("vote proposed")
+      const drMerkleRoot = 1
+      const tallyMerkleRoot = 1
+
+      // Fix the timestamp in witnet to be 89159
+      const setEpoch = contest.setEpoch(89159)
+      await waitForHash(setEpoch)
+      const epoch = await contest.updateEpoch.call()
+
+      // Update the ABS to be included
+      await contest.pushActivity(1)
+
+      // Propose the vote to the Block Relay that is going to be finalized
+      const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+      await waitForHash(tx)
+
+      // Wait unitl the next epoch to get the final result
+      await contest.nextEpoch()
+
+      // Propose another block in the next epoch so the previous one is finalized
+      await contest.proposeBlock(0, epoch, 0, 0, 0)
+
+      // Should revert beacause is proposing a blockHash already finalized
+      await truffleAssert.reverts(contest.proposeBlock(blockHash, epoch, drMerkleRoot, tallyMerkleRoot, 0),
+        "The block already existed")
+    })
+
+    it("should check candidates is deleted when posted", async () => {
+      // The array of vote-candidates should be deleted when a vote is finalized
+      // Block's hashes we want to propose
       const blockHash = "0x" + sha.sha256("the vote to propose")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
-      let setEpoch = contest.setEpoch(89159)
-      await waitForHash(setEpoch)
+      await contest.setEpoch(89159)
       let epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
+
       // Propose the vote to the Block Relay
       const tx = contest.proposeBlock(blockHash, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
+
       // Fix the timestamp to be one epoch later
-      setEpoch = contest.setEpoch(89160)
-      await waitForHash(setEpoch)
+      await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose another block in the next epoch so the previous one is finalized
       await contest.proposeBlock(0, epoch - 1, 0, 0, 0)
-      // The candidates array
+
+      // Get candidates length
       const candidate = await contest.getCandidatesLength.call()
-      // Assert there is just one candidate since the first is been canceled when posted
+      // Assert there is just one candidate since the first one is been deleted when posted
       assert.equal(1, candidate)
     })
 
-    it("should confirm blocks are been finalized", async () => {
-      // The idea is that after two epoch with no consesus, when in epoch n the consensus
-      // is achived epochs n-1 and n-2 are finalized as well
+    it("should confirm blocks are being finalized", async () => {
+      // After two epochs with no consesus, when in epoch n the consensus is achieved, epochs n-1
+      // and n-2 are finalized as well
+      // Block's hashes we want to propose
       const blockHash0 = "0x" + sha.sha256("null vote")
       const blockHash1 = "0x" + sha.sha256("first vote")
       const blockHash2 = "0x" + sha.sha256("second vote")
       const blockHash3 = "0x" + sha.sha256("third vote")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       let epoch = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the ABS to 3 members
       await contest.setAbsIdentitiesNumber(3)
+
       // Propose blockHash0 3 times to the Block Relay
       const tx = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
@@ -228,23 +308,33 @@ contract("New Block Relay", accounts => {
       await waitForHash(tx1)
       const tx2 = contest.proposeBlock(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx2)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote1 = await contest.getVote.call(blockHash0, epoch - 1, drMerkleRoot, tallyMerkleRoot, 0)
+
+      // Wait for next epoch
       await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose blockHash1 to the Block Relay
       const tx3 = contest.proposeBlock(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
       await waitForHash(tx3)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote2 = await contest.getVote.call(blockHash1, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
+
       // Wait for next epoch
       await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose blockHash2 to the Block Relay
       const tx7 = contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
       await waitForHash(tx7)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote3 = await contest.getVote.call(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
+
       // Wait for next epoch
       await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose 3 times blockHash3 to the Block Relay
       const tx4 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
       await waitForHash(tx4)
@@ -252,12 +342,16 @@ contract("New Block Relay", accounts => {
       await waitForHash(tx5)
       const tx6 = contest.proposeBlock(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
       await waitForHash(tx6)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote4 = await contest.getVote.call(blockHash3, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
+
       // Wait for next epoch
       await contest.nextEpoch()
       epoch = await contest.updateEpoch.call()
+
       // Propose a random vote just to finalize previous epochs
       await contest.proposeBlock(blockHash2, epoch - 1, drMerkleRoot, tallyMerkleRoot, Vote4)
+
       // Check the blockHash for epoch 89159 is the right one
       let FinalBlockHash1 = await contest.getBlockHash.call(89159)
       FinalBlockHash1 = "0x" + FinalBlockHash1.toString(16)
@@ -272,101 +366,53 @@ contract("New Block Relay", accounts => {
       assert.equal(FinalBlockHash3, blockHash3)
     })
 
-    it("should finalize a block and the previous epochs when Pending", async () => {
-      // The idea is that after two epoch with no consesus, when in epoch4 - 1 the consensus is achived then
-      // epoch1 - 1, epoch2 - 1 and epoch3 - 1 are finalized as well
-      const blockHash0 = "0x" + sha.sha256("null vote")
-      const blockHash1 = "0x" + sha.sha256("first vote")
-      const blockHash2 = "0x" + sha.sha256("second vote")
-      const blockHash3 = "0x" + sha.sha256("third vote")
-      const drMerkleRoot = 1
-      const tallyMerkleRoot = 1
-      // Fix the timestamp in witnet to be 89159
-      const setEpoch = contest.setEpoch(89159)
-      await waitForHash(setEpoch)
-      const epoch1 = await contest.updateEpoch.call()
-      // Update the ABS to be included
-      await contest.pushActivity(1)
-      // Set the ABS to 3 members
-      await contest.setAbsIdentitiesNumber(3)
-      // Propose blockHash0 to he Block Relay 3 times
-      const tx = contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await waitForHash(tx)
-      contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      const Vote = await contest.getVote.call(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
-      await contest.nextEpoch()
-      const epoch2 = await contest.updateEpoch.call()
-      // Propose blockHash1 to the Block Relay
-      const tx2 = contest.proposeBlock(blockHash1, epoch2 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
-      await waitForHash(tx2)
-      const Vote1 = await contest.getVote.call(blockHash1, epoch2 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      const epoch3 = await contest.updateEpoch.call()
-      // Propose blockHash2 to the Block Relay
-      const tx3 = contest.proposeBlock(blockHash2, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
-      await waitForHash(tx3)
-      const Vote2 = await contest.getVote.call(blockHash2, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote1)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      const epoch4 = await contest.updateEpoch.call()
-      // Propose 3 times blockHash3 to the Block Relay
-      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      contest.proposeBlock(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      const Vote3 = await contest.getVote.call(blockHash3, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote2)
-      // Wait for next epoch
-      await contest.nextEpoch()
-      const epoch5 = await contest.updateEpoch.call()
-      // Propose a random vote just to finalize previous epochs
-      await contest.proposeBlock(blockHash2, epoch5 - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      // Now we want to check that
-      let epochStatus = await contest.checkEpochFinalized.call(epoch4 - 1)
-      assert.equal(epochStatus, true)
-      epochStatus = await contest.checkEpochFinalized.call(epoch3 - 1)
-      assert.equal(epochStatus, true)
-      epochStatus = await contest.checkEpochFinalized.call(epoch2 - 1)
-      assert.equal(epochStatus, true)
-      epochStatus = await contest.checkEpochFinalized.call(epoch1 - 1)
-      assert.equal(epochStatus, true)
-    })
-
     it("should finalize a block even if previous epochs have no blocks proposed", async () => {
-      // Block Hashes to propose
+      // It should finalize the concatenation of blocks proposed when one is finalized
+      // If there are epochs with no blocks proposed between the finalized epochs, they should stay non-finalized
+      // Block's hashes to propose
       const blockHash0 = "0x" + sha.sha256("null vote")
       const blockHash1 = "0x" + sha.sha256("first vote")
       const blockHash2 = "0x" + sha.sha256("second vote")
       const drMerkleRoot = 1
       const tallyMerkleRoot = 1
+
       // Fix the timestamp in witnet to be 89159
       const setEpoch = contest.setEpoch(89159)
       await waitForHash(setEpoch)
       const epoch1 = await contest.updateEpoch.call()
+
       // Update the ABS to be included
       await contest.pushActivity(1)
       // Set the ABS to 3 members
       await contest.setAbsIdentitiesNumber(3)
+
       // Propose blockHash0 to he Block Relay
       const tx = contest.proposeBlock(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
       await waitForHash(tx)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote = await contest.getVote.call(blockHash0, epoch1 - 1, drMerkleRoot, tallyMerkleRoot, 0)
+
       // Set two epochs later with no blocks proposed in epoch2
       await contest.nextEpoch()
       const epoch2 = await contest.updateEpoch.call()
       await contest.nextEpoch()
       const epoch3 = await contest.updateEpoch.call()
+
       // Propose 3 times blockHash3 to the Block Relay
       contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
       contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
       contest.proposeBlock(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+      // Get the vote proposed as the concatenation of the inputs of the proposeBlock
       const Vote3 = await contest.getVote.call(blockHash1, epoch3 - 1, drMerkleRoot, tallyMerkleRoot, Vote)
+
       // Wait for next epoch
       await contest.nextEpoch()
       const epoch4 = await contest.updateEpoch.call()
+
       // Propose a random vote just to finalize previous epochs
       await contest.proposeBlock(blockHash2, epoch4 - 1, drMerkleRoot, tallyMerkleRoot, Vote3)
-      // Now we want to check that
+
+      // Check that the correct epochs are finalized
       let epochStatus = await contest.checkEpochFinalized.call(epoch3 - 1)
       assert.equal(epochStatus, true)
       epochStatus = await contest.checkEpochFinalized.call(epoch1 - 1)


### PR DESCRIPTION
- Adds NewBlockRelay.sol contract with proposing blocks function:
     - Only ABS members can propose blocks
     - Only blocks for the previous epoch are accepted
     - Posts the block when proposal epoch changes and when consensus is achieved
     - Finalized blocks automatically finalize previous blocks if they were not

- Adds tests to the new Block Relay with a Helper contract.

- Adds comments in README.md

- Adds absMemebership function in ActiveBridgeSetlibrary.sol.

This PR closes #36 #43 #39 