### PR TITLE
Rename contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # witnet-ethereum-bridge [![](https://travis-ci.com/witnet/witnet-ethereum-bridge.svg?branch=master)](https://travis-ci.com/witnet/witnet-ethereum-brdige)
 
-`witnet-ethereum-bridge` is an open source implementation of a bridge 
+`witnet-ethereum-bridge` is an open source implementation of a bridge
 from Ethereum to Witnet. This repository provides several contracts:
 
-- The `Witnet Bridge Interface`(WBI), which includes all the needed 
+- The `Witnet Requests Board` (WRB), which includes all the needed
 functionality to relay data requests and their results from Ethereum to Witnet and the other way round.
-- `UsingWitnet`, an inheritable client contract that injects methods for interacting with the WBI in the most convenient way.
+- `UsingWitnet`, an inheritable client contract that injects methods for interacting with the WRB in the most convenient way.
 
-## WitnetBridgeInterface
+## WitnetRequestsBoard
 
-The `WitnetBridgeInterface` contract provides the following methods:
+The `WitnetRequestsBoard` contract provides the following methods:
 
 - **postDataRequest**:
-  - _description_: posts a data request into the WBI in expectation that it will be relayed and resolved 
+  - _description_: posts a data request into the WRB in expectation that it will be relayed and resolved 
   in Witnet with a total reward that equals to msg.value.
   - _inputs_:
     - *_dr*: the bytes corresponding to the Protocol Buffers serialization of the data request output.
@@ -58,21 +58,21 @@ The `WitnetBridgeInterface` contract provides the following methods:
     - *_result*: the result itself as `bytes`.
 
 - **readDataRequest**:
-  - _description_: retrieves the bytes of the serialization of one data request from the WBI.
+  - _description_: retrieves the bytes of the serialization of one data request from the WRB.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
   - _output_:
     - the data request bytes.
 
 - **readResult**:
-  - _description_: retrieves the result (if already available) of one data request from the WBI.
+  - _description_: retrieves the result (if already available) of one data request from the WRB.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
   - _output_:
     - the result of the data request as `bytes`.
 
 - **readDrHash**:
-  - _description_: retrieves the data request transaction hash in Witnet (if it has already been included and presented) of one data request from the WBI.
+  - _description_: retrieves the data request transaction hash in Witnet (if it has already been included and presented) of one data request from the WRB.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
   - _output_:
@@ -92,9 +92,9 @@ The `WitnetBridgeInterface` contract provides the following methods:
   - _description_: checks whether an identity is part of the Active Bridge Set.
   - _output_: true if the identity is member of the ABS. 
 
-In addition, `WitnetBridgeInterface` inherits the `VRF` contract from https://github.com/witnet/vrf-solidity, and as such, all its public methods are also available to be queried. This is extremely important as the proof of eligibility is verified with the `fastVerify` method, which requires some auxiliary data points in addition to the proof itself. These can be calculated using the following methods:
+In addition, `WitnetRequestsBoard` inherits the `VRF` contract from https://github.com/witnet/vrf-solidity, and as such, all its public methods are also available to be queried. This is extremely important as the proof of eligibility is verified with the `fastVerify` method, which requires some auxiliary data points in addition to the proof itself. These can be calculated using the following methods:
 
-- *computeFastVerifyParams*: which computes the necessary auxiliary points to perform the fast (and cheaper) verification in the WBI.
+- *computeFastVerifyParams*: which computes the necessary auxiliary points to perform the fast (and cheaper) verification in the WRB.
 - *decodeProof*: if the proof is serialized and needs to be decomposed, this function decodes a VRF proof into the parameters [Gamma_x, Gamma_y c, s].
 - *decodePoint*: if the point is in compressed format, this function decodes a compressed secp256k1 point into its uncompressed representation [P_x, P_y].
 
@@ -103,8 +103,8 @@ In addition, `WitnetBridgeInterface` inherits the `VRF` contract from https://gi
 The `UsingWitnet` contract injects the following methods into the contracts inheriting from it:
 
 - **witnetPostDataRequest**:
-  - _description_: call to the WBI's `postDataRequest` method to post a 
-  data request into the WBI so its is resolved in Witnet with total reward 
+  - _description_: call to the WRB's `postDataRequest` method to post a 
+  data request into the WRB so its is resolved in Witnet with total reward 
   specified in `msg.value`.
   - _inputs_:
     - *_dr*: the bytes corresponding to the Protocol Buffers serialization of the data request output.
@@ -114,15 +114,15 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
     - *_id*: the unique identifier of the data request.
 
 - **witnetUpgradeDataRequest**:
-  - _description_: call to the WBI's `upgradeDataRequest` method to increment 
+  - _description_: call to the WRB's `upgradeDataRequest` method to increment 
   the total reward of the data request by adding more value to it. The new request reward will be increased by `msg.value` minus the difference between the former tally reward and the new tally reward.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
     - *_tallyReward*: the new tally reward. Needs to be equal or greater than the former tally reward.
 
 - **witnetReadResult**:
-  - _description_: call to the WBI's `readResult` method to retrieve
-   the result of one data request from the WBI.
+  - _description_: call to the WRB's `readResult` method to retrieve
+   the result of one data request from the WRB.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
   - _output_:

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -84,7 +84,7 @@ library ActiveBridgeSetLib {
   }
 
   /// @dev Checks if an address is a member of the ABS
-  /// @param _abs The Active Bridge Set structure from the Witnet Bridge Interface.
+  /// @param _abs The Active Bridge Set structure from the Witnet Requests Board.
   /// @param _address The address to check.
   /// @return true or false
   function absMembership(ActiveBridgeSet storage _abs, address _address) internal view returns (bool) {

--- a/contracts/Request.sol
+++ b/contracts/Request.sol
@@ -10,7 +10,7 @@ contract Request {
 
   // A `Request` is constructed around a `bytes memory` value containing a well-formed Witnet data request serialized
   // using Protocol Buffers. However, we cannot verify its validity at this point. This implies that contracts using
-  // the WBI should not be considered trustless before a valid Proof-of-Inclusion has been posted for the requests.
+  // the WRB should not be considered trustless before a valid Proof-of-Inclusion has been posted for the requests.
   //
   // The hash of the request is computed in the constructor to guarantee consistency. Otherwise there could be a
   // mismatch and a data request could be resolved with the result of another.

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.0;
 
 import "./Request.sol";
 import "./Witnet.sol";
-import "./WitnetBridgeInterface.sol";
+import "./WitnetRequestsBoard.sol";
 
 
 /**
@@ -13,14 +13,14 @@ import "./WitnetBridgeInterface.sol";
 contract UsingWitnet {
   using Witnet for Witnet.Result;
 
-  WitnetBridgeInterface wbi;
+  WitnetRequestsBoard wrb;
 
   /**
-  * @notice Include an address to specify the WitnetBridgeInterface
-  * @param _wbi WitnetBridgeInterface address
+  * @notice Include an address to specify the WitnetRequestsBoard
+  * @param _wrb WitnetRequestsBoard address
   */
-  constructor (address _wbi) public {
-    wbi = WitnetBridgeInterface(_wbi);
+  constructor (address _wrb) public {
+    wrb = WitnetRequestsBoard(_wrb);
   }
 
   // Provides a convenient way for client contracts extending this to block the execution of the main logic of the
@@ -32,48 +32,48 @@ contract UsingWitnet {
 
   /**
   * @notice Send a new request to the Witnet network
-  * @dev Call to `post_dr` function in the WitnetBridgeInterface contract
+  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
   * @param _request An instance of the `Request` contract
   * @param _requestReward Reward specified for the user which posts the request into Witnet
   * @param _resultReward Reward specified for the user which posts back the request result
-  * @return Sequencial identifier for the request included in the WitnetBridgeInterface
+  * @return Sequencial identifier for the request included in the WitnetRequestsBoard
   */
   function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward) internal returns (uint256 id) {
-    return wbi.postDataRequest.value(_requestReward + _resultReward)(_request.bytecode(), _resultReward);
+    return wrb.postDataRequest.value(_requestReward + _resultReward)(_request.bytecode(), _resultReward);
   }
 
   /**
   * @notice Check if a request has been accepted into Witnet
   * @dev Contracts depending on Witnet should not start their main business logic (e.g. receiving value from third
   * parties) before this method returns `true`
-  * @param _id The sequential identifier of a request that has been previously sent to the WitnetBridgeInterface
+  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard
   * @return A boolean telling if the request has been already accepted or not. `false` do not mean rejection, though
   */
   function witnetCheckRequestAccepted(uint256 _id) internal view returns (bool) {
     // Find the request in the
-    (,,,,,uint256 drHash,) = wbi.requests(_id);
+    (,,,,,uint256 drHash,) = wrb.requests(_id);
     // If the hash of the data request transaction in Witnet is not the default, then it means that inclusion of the
-    // request has been proven to the WBI.
+    // request has been proven to the WRB.
     return drHash != 0;
   }
 
   /**
   * @notice Upgrade the rewards for a Data Request previously included
-  * @dev Call to `upgrade_dr` function in the WitnetBridgeInterface contract
-  * @param _id The sequential identifier of a request that has been previously sent to the WitnetBridgeInterface
+  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract
+  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard
   * @param _tallyReward Reward specified for the user which post the Data Request result
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) internal {
-    wbi.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
+    wrb.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
   }
 
   /**
   * @notice Read the result of a resolved request
-  * @dev Call to `read_result` function in the WitnetBridgeInterface contract
+  * @dev Call to `read_result` function in the WitnetRequestsBoard contract
   * @param _id The sequential identifier of a request that was posted to Witnet
   * @return The result of the request as an instance of `Result`
   */
   function witnetReadResult(uint256 _id) internal view returns (Witnet.Result memory) {
-    return Witnet.resultFromCborBytes(wbi.readResult(_id));
+    return Witnet.resultFromCborBytes(wrb.readResult(_id));
   }
 }

--- a/contracts/UsingWitnetBytes.sol
+++ b/contracts/UsingWitnetBytes.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "./WitnetBridgeInterface.sol";
+import "./WitnetRequestsBoard.sol";
 
 
 /**
@@ -10,59 +10,59 @@ import "./WitnetBridgeInterface.sol";
  */
 contract UsingWitnetBytes {
 
-  WitnetBridgeInterface wbi;
+  WitnetRequestsBoard wrb;
 
   /**
-  * @notice Include an address to specify the WitnetBridgeInterface
-  * @param _wbi WitnetBridgeInterface address
+  * @notice Include an address to specify the WitnetRequestsBoard
+  * @param _wrb WitnetRequestsBoard address
   */
-  constructor (address _wbi) public {
-    wbi = WitnetBridgeInterface(_wbi);
+  constructor (address _wrb) public {
+    wrb = WitnetRequestsBoard(_wrb);
   }
 
   /**
   * @notice Include a new Data Request to be resolved by Witnet network
-  * @dev Call to `post_dr` function in the WitnetBridgeInterface contract
+  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
   * @param _requestBytes Data Request bytes
   * @param _tallyReward Reward specified for the user which post the Data Request result
-  * @return Identifier for the Data Request included in the WitnetBridgeInterface
+  * @return Identifier for the Data Request included in the WitnetRequestsBoard
   */
   function witnetPostRequest(bytes memory _requestBytes, uint256 _tallyReward) internal returns(uint256 id) {
-    return wbi.postDataRequest.value(msg.value)(_requestBytes, _tallyReward);
+    return wrb.postDataRequest.value(msg.value)(_requestBytes, _tallyReward);
   }
 
   /**
   * @notice Check if a request has been accepted into Witnet
   * @dev Contracts depending on Witnet should not start their main business logic (e.g. receiving value from third
   * parties) before this method returns `true`.
-  * @param _id The id of a request that has been previously sent to the WitnetBridgeInterface.
+  * @param _id The id of a request that has been previously sent to the WitnetRequestsBoard.
   * @return A boolean telling if the request has been already accepted or not. `false` do not mean rejection, though.
   */
   function witnetCheckRequestAccepted(uint256 _id) internal view returns(bool) {
     // Find the request in the
-    (,,,,,uint256 drHash,) = wbi.requests(_id);
+    (,,,,,uint256 drHash,) = wrb.requests(_id);
     // If the hash of the data request transaction in Witnet is not the default, then it means that inclusion of the
-    // request has been proven to the WBI.
+    // request has been proven to the WRB.
     return drHash != 0;
   }
 
   /**
   * @notice Upgrade the rewards for a Data Request previously included
-  * @dev Call to `upgrade_dr` function in the WitnetBridgeInterface contract
-  * @param _id Identifier for the Data Request included in the WitnetBridgeInterface
+  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract
+  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard
   * @param _tallyReward Reward specified for the user which post the Data Request result
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) internal {
-    wbi.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
+    wrb.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
   }
 
   /**
   * @notice Read the result of a resolved Data Request
-  * @dev Call to `read_result` function in the WitnetBridgeInterface contract
-  * @param _id Identifier for the Data Request included in the WitnetBridgeInterface
+  * @dev Call to `read_result` function in the WitnetRequestsBoard contract
+  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard
   * @return Data Request result
   */
   function witnetReadResult (uint256 _id) internal view returns(bytes memory) {
-    return wbi.readResult(_id);
+    return wrb.readResult(_id);
   }
 }

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -4,17 +4,17 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "./ActiveBridgeSetLib.sol";
 import "block-relay/contracts/BlockRelayProxy.sol";
-import "./WBIInterface.sol";
+import "./WitnetRequestsBoardInterface.sol";
 
 
 /**
- * @title Witnet Bridge Interface
+ * @title Witnet Requests Board
  * @notice Contract to bridge requests to Witnet
  * @dev This contract enables posting requests that Witnet bridges will insert into the Witnet network
   * The result of the requests will be posted back to this contract by the bridge nodes too.
  * @author Witnet Foundation
  */
-contract WitnetBridgeInterface is WBIInterface {
+contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
 
   using SafeMath for uint256;
   using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
@@ -119,7 +119,7 @@ contract WitnetBridgeInterface is WBIInterface {
     repFactor = _repFactor;
   }
 
-  /// @dev Posts a data request into the WBI in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
+  /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
@@ -236,14 +236,14 @@ contract WitnetBridgeInterface is WBIInterface {
     }
   }
 
-  /// @dev Retrieves the bytes of the serialization of one data request from the WBI.
+  /// @dev Retrieves the bytes of the serialization of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the data request as bytes.
   function readDataRequest (uint256 _id) external view returns(bytes memory) {
     return requests[_id].dr;
   }
 
-  /// @dev Retrieves the result (if already available) of one data request from the WBI.
+  /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
   function readResult (uint256 _id) external view returns(bytes memory) {
@@ -257,8 +257,8 @@ contract WitnetBridgeInterface is WBIInterface {
     return requests[_id].drHash;
   }
 
-  /// @dev Number of data requests in the WBI.
-  /// @return Returns the number of data requests in the WBI.
+  /// @dev Number of data requests in the WRB.
+  /// @return Returns the number of data requests in the WRB.
   function requestsCount() external view returns(uint256) {
     return requests.length;
   }

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -1,15 +1,15 @@
 pragma solidity ^0.5.0;
 /**
- * @title WBI Interface
- * @notice Interface of a WBI
- * It defines how to interact with the WBI in order to support:
+ * @title Witnet Requests Board Interface
+ * @notice Interface of a Witnet Request Board (WRB)
+ * It defines how to interact with the WRB in order to support:
  *  - Post and upgrade a data request
  *  - Read the result of a dr
  * @author Witnet Foundation
  */
-interface WBIInterface {
+interface WitnetRequestsBoardInterface {
 
-  /// @dev Posts a data request into the WBI in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
+  /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
@@ -25,7 +25,7 @@ interface WBIInterface {
     external
     payable;
 
-  /// @dev Retrieves the result (if already available) of one data request from the WBI.
+  /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
   function readResult (uint256 _id) external view returns(bytes memory);

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -1,16 +1,16 @@
 pragma solidity ^0.5.0;
 
-import "../WBIInterface.sol";
+import "../WitnetRequestsBoardInterface.sol";
 
 
 /**
- * @title Witnet Bridge Interface mocked
+ * @title Witnet Requests Board mocked
  * @notice Contract to bridge requests to Witnet for testing purposes.
  * @dev This contract enables posting requests that Witnet bridges will insert into the Witnet network.
   * The result of the requests will be posted back to this contract by the bridge nodes too.
  * @author Witnet Foundation
  */
-contract MockWitnetBridgeInterface is WBIInterface {
+contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
 
   struct DataRequest {
     bytes dr;
@@ -30,7 +30,7 @@ contract MockWitnetBridgeInterface is WBIInterface {
     requests.push(request);
   }
 
-  /// @dev Posts a data request into the WBI in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
+  /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
@@ -73,7 +73,7 @@ contract MockWitnetBridgeInterface is WBIInterface {
     msg.sender.transfer(requests[_id].tallyReward);
   }
 
-  /// @dev Retrieves the result (if already available) of one data request from the WBI.
+  /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR.
   function readResult (uint256 _id) external view returns(bytes memory) {

--- a/migrations/3_deploy_wbi.js
+++ b/migrations/3_deploy_wbi.js
@@ -1,7 +1,7 @@
-var WBI = artifacts.require("WitnetBridgeInterface")
+var WRB = artifacts.require("WitnetRequestsBoard")
 var BlockRelayProxy = artifacts.require("BlockRelayProxy")
 
 module.exports = function (deployer, network) {
-  console.log(`> Migrating WBI into ${network} network`)
-  deployer.deploy(WBI, BlockRelayProxy.address, 2)
+  console.log(`> Migrating WRB into ${network} network`)
+  deployer.deploy(WRB, BlockRelayProxy.address, 2)
 }

--- a/migrations/addresses.json
+++ b/migrations/addresses.json
@@ -3,6 +3,6 @@
     "BlockRelayProxy" : "0xCD835FB8B7359550Cd378f6b048374cE6Da423A8"
   },
   "goerli" : {
-    "BlockRelayProxy" : "0xab55369585B03398fDf359D1bAA0D48995C1832A"
+  "BlockRelayProxy" : "0xab55369585B03398fDf359D1bAA0D48995C1832A"
   }
 }

--- a/test/helpers/UsingWitnetBytesTestHelper.sol
+++ b/test/helpers/UsingWitnetBytesTestHelper.sol
@@ -11,7 +11,7 @@ import "../../contracts/UsingWitnetBytes.sol";
  */
 contract UsingWitnetBytesTestHelper is UsingWitnetBytes {
 
-  constructor (address _wbiAddress) UsingWitnetBytes(_wbiAddress) public {}
+  constructor (address _wrbAddress) UsingWitnetBytes(_wrbAddress) public {}
 
   function _witnetPostDataRequest(bytes memory _dr, uint256 _tallyReward) public payable returns(uint256 id) {
     return witnetPostRequest(_dr, _tallyReward);

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -17,7 +17,7 @@ contract UsingWitnetTestHelper is UsingWitnet {
 
   Witnet.Result public result;
 
-  constructor (address _wbiAddress) UsingWitnet(_wbiAddress) public { }
+  constructor (address _wrbAddress) UsingWitnet(_wrbAddress) public { }
 
   function _witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward) public payable returns(uint256 id) {
     return witnetPostRequest(_request, _requestReward, _resultReward);

--- a/test/helpers/WitnetRequestsBoardTestHelper.sol
+++ b/test/helpers/WitnetRequestsBoardTestHelper.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.0;
 
-import "../../contracts/WitnetBridgeInterface.sol";
+import "../../contracts/WitnetRequestsBoard.sol";
 
 
 /**
- * @title Test Helper for the WBI contract
+ * @title Test Helper for the WRB contract
  * @dev The aim of this contract is:
- * 1. Raise the visibility modifier of wbi contract functions for testing purposes
+ * 1. Raise the visibility modifier of wrb contract functions for testing purposes
  * @author Witnet Foundation
  */
 
 
-contract WBITestHelper is WitnetBridgeInterface {
-  WitnetBridgeInterface wbi;
+contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
+  WitnetRequestsBoard wrb;
   //uint256 blockHash;
   // epoch of the last block
   //uint256 epoch;
@@ -22,7 +22,7 @@ contract WBITestHelper is WitnetBridgeInterface {
   constructor (
     address _blockRelayAddress,
     uint8 _repFactor)
-  WitnetBridgeInterface(_blockRelayAddress, _repFactor) public { }
+  WitnetRequestsBoard(_blockRelayAddress, _repFactor) public { }
 
   modifier vrfValid(
     uint256[4] memory _poe,

--- a/test/internal.js
+++ b/test/internal.js
@@ -1,26 +1,26 @@
-const WBITestHelper = artifacts.require("WBITestHelper")
+const WitnetRequestsBoardTestHelper = artifacts.require("WitnetRequestsBoardTestHelper")
 const MockBlockRelay = artifacts.require("MockBlockRelay")
 const BlockRelayProxy = artifacts.require("BlockRelayProxy")
 const testdata = require("./internals.json")
 
-contract("WBITestHelper - internals", accounts => {
-  describe("WBI underlying algorithms: ", () => {
+contract("WitnetRequestsBoardTestHelper - internals", accounts => {
+  describe("WRB underlying algorithms: ", () => {
     let blockRelay
     let blockRelayProxy
-    let wbiHelper
+    let wrbHelper
     before(async () => {
       blockRelay = await MockBlockRelay.new()
       blockRelayProxy = await BlockRelayProxy.new(blockRelay.address, {
         from: accounts[0],
       })
-      wbiHelper = await WBITestHelper.new(blockRelayProxy.address, 2)
+      wrbHelper = await WitnetRequestsBoardTestHelper.new(blockRelayProxy.address, 2)
     })
     for (const [index, test] of testdata.sig.valid.entries()) {
       it(`sig (${index + 1})`, async () => {
         const message = web3.utils.fromAscii(test.message)
         const pubKey = test.public_key
         const sig = test.signature
-        const result = await wbiHelper._verifySig.call(message, pubKey, sig)
+        const result = await wrbHelper._verifySig.call(message, pubKey, sig)
         assert.equal(result, true)
       })
     }
@@ -29,16 +29,16 @@ contract("WBITestHelper - internals", accounts => {
         const message = web3.utils.fromAscii(test.message)
         const pubKey = test.public_key
         const sig = test.signature
-        const result = await wbiHelper._verifySig.call(message, pubKey, sig)
+        const result = await wrbHelper._verifySig.call(message, pubKey, sig)
         assert.notEqual(result, true)
       })
     }
     for (const [index, test] of testdata.poe.valid.entries()) {
       it(`valid poe (${index + 1})`, async () => {
         const publicKey = testdata.poe.publicKey
-        await wbiHelper.setActiveIdentities(test.abs)
+        await wrbHelper.setActiveIdentities(test.abs)
 
-        const result = await wbiHelper._verifyPoe.call(
+        const result = await wrbHelper._verifyPoe.call(
           [test.vrf, 0, 0, 0],
           publicKey,
           [0, 0],
@@ -49,9 +49,9 @@ contract("WBITestHelper - internals", accounts => {
     for (const [index, test] of testdata.poe.invalid.entries()) {
       it(`invalid poe (${index + 1})`, async () => {
         const publicKey = testdata.poe.publicKey
-        await wbiHelper.setActiveIdentities(test.abs)
+        await wrbHelper.setActiveIdentities(test.abs)
 
-        const result = await wbiHelper._verifyPoe.call(
+        const result = await wrbHelper._verifyPoe.call(
           [test.vrf, 0, 0, 0],
           publicKey,
           [0, 0],


### PR DESCRIPTION
Renamed contracts:
1. WintetBrindgeInterface to WitnetRequestsBoard
2. WBIInterface to WitnetRequestsBoardInterface
3. WBITestHelper to WitnetRequestsBoardTestHelper
4. MockWitnetBrdgeinterface to MockWitnetRequestsBoard

The changes have been applied to tests and README

This PR is part of #58 