### PR TITLE
fix: rename block-relay in package.json

### DIFF
--- a/contracts/WitnetBridgeInterface.sol
+++ b/contracts/WitnetBridgeInterface.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "./ActiveBridgeSetLib.sol";
-import "block-relay/contracts/BlockRelayProxy.sol";
+import "witnet-ethereum-block-relay/contracts/BlockRelayProxy.sol";
 import "./WBIInterface.sol";
 
 

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.5.0;
-import "block-relay/contracts/BlockRelayInterface.sol";
+import "witnet-ethereum-block-relay/contracts/BlockRelayInterface.sol";
 
 /**
  * @title Block relay contract

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "block-relay": "witnet/witnet-ethereum-block-relay#master",
+    "witnet-ethereum-block-relay": "witnet/witnet-ethereum-block-relay#master",
     "openzeppelin-solidity": "2.4.0",
     "vrf-solidity": "^0.2.1"
   },


### PR DESCRIPTION
Rename in package.json and in contracts that import contracts from it:
block-relay ==> witnet-ethereum-block-relay

Closes #61 