### PR TITLE
[BRProxy] Add epoch as argument

### DIFF
--- a/contracts/WitnetBridgeInterface.sol
+++ b/contracts/WitnetBridgeInterface.sol
@@ -176,11 +176,13 @@ contract WitnetBridgeInterface is WBIInterface {
   /// @param _poi A proof of inclusion proving that the data request appears listed in one recent block in Witnet.
   /// @param _index The index in the merkle tree.
   /// @param _blockHash The hash of the block in which the data request was inserted.
+  /// @param _epoch The epoch in which the blockHash was created.
   function reportDataRequestInclusion (
     uint256 _id,
     uint256[] calldata _poi,
     uint256 _index,
-    uint256 _blockHash
+    uint256 _blockHash,
+    uint256 _epoch
     )
     external
     drNotIncluded(_id)
@@ -190,6 +192,7 @@ contract WitnetBridgeInterface is WBIInterface {
     if (blockRelay.verifyDrPoi(
       _poi,
       _blockHash,
+      _epoch,
       _index,
       drOutputHash)) {
       requests[_id].drHash = drHash;
@@ -207,12 +210,14 @@ contract WitnetBridgeInterface is WBIInterface {
   /// @param _poi A proof of inclusion proving that the data in _result has been acknowledged by the Witnet network as being the final result for the data request by putting in a tally transaction inside a Witnet block.
   /// @param _index The position of the tally transaction in the tallies-only merkle tree in the Witnet block.
   /// @param _blockHash The hash of the block in which the result (tally) was inserted.
+  /// @param _epoch The epoch in which the blockHash was created.
   /// @param _result The result itself as bytes.
   function reportResult (
     uint256 _id,
     uint256[] calldata _poi,
     uint256 _index,
     uint256 _blockHash,
+    uint256 _epoch,
     bytes calldata _result
     )
     external
@@ -224,6 +229,7 @@ contract WitnetBridgeInterface is WBIInterface {
     if (blockRelay.verifyTallyPoi(
       _poi,
       _blockHash,
+      _epoch,
       _index,
       resHash)){
       requests[_id].result = _result;

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -67,6 +67,18 @@ contract MockBlockRelay is BlockRelayInterface {
     return abi.encodePacked(lastBlock.blockHash, lastBlock.epoch);
   }
 
+  /// @notice Returns the lastest epoch reported to the block relay.
+  /// @return epoch
+  function getLastEpoch() external view returns(uint256) {
+    return lastBlock.epoch;
+  }
+
+  /// @notice Returns the latest hash reported to the block relay
+  /// @return blockhash
+  function getLastHash() external view returns(uint256){
+    return lastBlock.blockHash;
+  }
+
   /// @dev Verifies the validity of a PoI against the DR merkle root
   /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
   /// @param _blockHash the blockHash

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -75,7 +75,7 @@ contract MockBlockRelay is BlockRelayInterface {
 
   /// @notice Returns the latest hash reported to the block relay
   /// @return blockhash
-  function getLastHash() external view returns(uint256){
+  function getLastHash() external view returns(uint256) {
     return lastBlock.blockHash;
   }
 

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -167,10 +167,11 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should prove inclusion of the request into Witnet", async () => {
+      const epoch = 1
       await returnData(wbi.reportDataRequestInclusion(requestId,
         ["0xe1504f07d07c513c7cd919caec111b900c893a5f9ba82c4243893132aaf087f8"],
         0,
-        block1Hash), {
+        block1Hash, epoch), {
         from: accounts[1],
       })
 
@@ -195,7 +196,8 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should post the result of the request into the WBI", async () => {
-      await returnData(wbi.reportResult(requestId, [], 0, block2Hash, resultHex))
+      const epoch = 0
+      await returnData(wbi.reportResult(requestId, [], 0, block2Hash, epoch, resultHex))
       const requestInfo = await wbi.requests(requestId)
       assert.equal(requestInfo.result, resultHex)
     })
@@ -276,10 +278,11 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should prove inclusion of the request into Witnet", async () => {
+      const epoch = 3
       await returnData(wbi.reportDataRequestInclusion(requestId,
         ["0xe1504f07d07c513c7cd919caec111b900c893a5f9ba82c4243893132aaf087f8"],
         0,
-        block3Hash), {
+        block3Hash, epoch), {
         from: accounts[1],
       })
 
@@ -298,7 +301,8 @@ contract("UsingWitnet", accounts => {
     })
 
     it("Should report the result in the WBI", async () => {
-      await returnData(wbi.reportResult(requestId, [], 0, block4Hash, resultHex))
+      const epoch = 0
+      await returnData(wbi.reportResult(requestId, [], 0, block4Hash, epoch, resultHex))
       const requestinfo = await wbi.requests(requestId)
       assert.equal(requestinfo.result, resultHex)
     })

--- a/test/using_witnet_bytes.js
+++ b/test/using_witnet_bytes.js
@@ -152,14 +152,14 @@ contract("UsingWitnetBytes", accounts => {
       const tx3 = wbi.reportDataRequestInclusion(expectedId,
         ["0xe1504f07d07c513c7cd919caec111b900c893a5f9ba82c4243893132aaf087f8"],
         0,
-        expectedBlockHash)
+        expectedBlockHash, epoch)
       await waitForHash(tx3)
       const drInfo3 = await wbi.requests(expectedId)
       const DrHash = drInfo3.drHash
       assert.equal(expectedDrHash, web3.utils.toHex(DrHash))
       // Report result
       const tx4 = wbi.reportResult(expectedId, [], 0,
-        expectedBlockHash, web3.utils.utf8ToHex(stringRes))
+        expectedBlockHash, epoch, web3.utils.utf8ToHex(stringRes))
       await waitForHash(tx4)
 
       const drInfo4 = await wbi.requests(expectedId)

--- a/test/wbi.js
+++ b/test/wbi.js
@@ -180,7 +180,7 @@ contract("WBI", accounts => {
       const beacon = await wbiInstance.getLastBeacon.call()
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
 
-      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [drOutputHash], 0, blockHeader, {
+      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [drOutputHash], 0, blockHeader, epoch, {
         from: account2,
       })
 
@@ -190,7 +190,7 @@ contract("WBI", accounts => {
       assert(parseInt(afterBalance2, 10) > parseInt(actualBalance2, 10))
 
       // report result
-      const restx = wbiInstance.reportResult(id1, [], 0, blockHeader, resBytes, { from: account2 })
+      const restx = wbiInstance.reportResult(id1, [], 0, blockHeader, epoch, resBytes, { from: account2 })
       await waitForHash(restx)
 
       // check payment of result reporting
@@ -314,13 +314,13 @@ contract("WBI", accounts => {
       await waitForHash(tx2)
 
       // report data request inclusion
-      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader, {
+      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader, epoch, {
         from: accounts[1],
       })
       await waitForHash(tx3)
 
       // report result
-      const tx4 = await wbiInstance.reportResult(id1, [], 0, blockHeader, resBytes, {
+      const tx4 = await wbiInstance.reportResult(id1, [], 0, blockHeader, epoch, resBytes, {
         from: accounts[2],
       })
 
@@ -378,7 +378,7 @@ contract("WBI", accounts => {
       await waitForHash(tx2)
 
       // should fail to read blockhash from a non-existing block
-      await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySibling], 2, fakeBlockHeader, {
+      await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySibling], 2, fakeBlockHeader, epoch, {
         from: accounts[1],
       }), "Non-existing block")
     })
@@ -478,6 +478,7 @@ contract("WBI", accounts => {
       const resBytes = web3.utils.fromAscii("This is a result")
       const data1 = "0x" + sha.sha256(web3.utils.hexToBytes(drBytes))
       var dummySybling = 1
+      const epoch = 0
 
       // VRF params
       const publicKey = [data.publicKey.x, data.publicKey.y]
@@ -535,13 +536,13 @@ contract("WBI", accounts => {
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
 
       // post data request inclusion
-      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader2, {
+      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader2, epoch, {
         from: accounts[0],
       })
       await waitForHash(tx3)
 
       // assert it fails when trying to report the dr inclusion again
-      await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySybling], 1, blockHeader2, {
+      await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySybling], 1, blockHeader2, epoch, {
         from: accounts[1],
       }), "DR already included")
     })
@@ -590,7 +591,7 @@ contract("WBI", accounts => {
 
       // assert reporting a result when inclusion has not been proved fails
       await truffleAssert.reverts(
-        wbiInstance.reportResult(id1, [dummySybling], 1, blockHeader, resBytes, { from: accounts[1] }),
+        wbiInstance.reportResult(id1, [dummySybling], 1, blockHeader, epoch, resBytes, { from: accounts[1] }),
         "DR not yet included"
       )
     })
@@ -651,18 +652,18 @@ contract("WBI", accounts => {
       assert.equal(beacon, web3.utils.bytesToHex(concatenated))
 
       // report data request inclusion
-      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader2, {
+      const tx3 = wbiInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader2, epoch2, {
         from: accounts[0],
       })
       await waitForHash(tx3)
 
       // report result
-      const tx4 = wbiInstance.reportResult(id1, [], 0, blockHeader2, resBytes, { from: accounts[1] })
+      const tx4 = wbiInstance.reportResult(id1, [], 0, blockHeader2, epoch2, resBytes, { from: accounts[1] })
       await waitForHash(tx4)
 
       // revert when reporting the same result
       await truffleAssert.reverts(
-        wbiInstance.reportResult(id1, [], 1, blockHeader2, resBytes, { from: accounts[1] }),
+        wbiInstance.reportResult(id1, [], 1, blockHeader2, epoch2, resBytes, { from: accounts[1] }),
         "Result already included"
       )
     })

--- a/test/wbi.js
+++ b/test/wbi.js
@@ -378,9 +378,10 @@ contract("WBI", accounts => {
       await waitForHash(tx2)
 
       // should fail to read blockhash from a non-existing block
-      await truffleAssert.reverts(wbiInstance.reportDataRequestInclusion(id1, [dummySibling], 2, fakeBlockHeader, epoch, {
-        from: accounts[1],
-      }), "Non-existing block")
+      await truffleAssert.reverts(
+        wbiInstance.reportDataRequestInclusion(id1, [dummySibling], 2, fakeBlockHeader, epoch, {
+          from: accounts[1],
+        }), "Non-existing block")
     })
     it("should revert because the rewards are higher than the values sent. " +
        "Checks the post data request transaction",


### PR DESCRIPTION
Add epoch as an argument in Witnet Bridge Interface (to be changed to Witnet Requests Board) in:

- ReportResult
- ReportDataRequestInclusion

The tests wbi, usingwitnet have been changed to make them work with the new argument.

This argument is needed in the BlockRelayProxy to point the right Block Relay.