### PR TITLE
[WIP] chore: update versions and fix code review errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage.json
 .env
 .idea
 .vscode
+
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.json
 .vscode
 
 yarn.lock
+package-lock.json

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -84,10 +84,10 @@ library ActiveBridgeSetLib {
     return true;
   }
 
-  /// @dev Checks if an address is a member of the ABS
+  /// @dev Checks if an address is a member of the ABS.
   /// @param _abs The Active Bridge Set structure from the Witnet Requests Board.
   /// @param _address The address to check.
-  /// @return true or false
+  /// @return true if address is member of ABS.
   function absMembership(ActiveBridgeSet storage _abs, address _address) internal view returns (bool) {
     return _abs.identityCount[_address] > 0;
   }
@@ -95,7 +95,7 @@ library ActiveBridgeSetLib {
   /// @dev Gets the slots of the last block seen by the ABS provided and the block number provided.
   /// @param _abs The Active Bridge Set structure containing the last block.
   /// @param _blockNumber The block number from which to get the current slot.
-  /// @return (currentSlot, lastSlot, overflow), where overflow implies the block difference &gt; CLAIM_BLOCK_PERIOD* ACTIVITY_LENGTH
+  /// @return (currentSlot, lastSlot, overflow), where overflow implies the block difference &gt; CLAIM_BLOCK_PERIOD* ACTIVITY_LENGTH.
   function getSlots(ActiveBridgeSet storage _abs, uint256 _blockNumber) private view returns (uint16, uint16, bool) {
     // Get current activity slot number
     uint16 currentSlot = uint16((_blockNumber / CLAIM_BLOCK_PERIOD) % ACTIVITY_LENGTH);

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 
 
 /**
@@ -63,7 +63,8 @@ library ActiveBridgeSetLib {
       _abs.lastBlockNumber = _blockNumber;
     } else {
       // Check if address was already counted as active identity in this current activity slot
-      for (uint i; i < _abs.epochIdentities[currentSlot].length; i++) {
+      uint256 epochIdsLength = _abs.epochIdentities[currentSlot].length;
+      for (uint i; i < epochIdsLength; i++) {
         if (_abs.epochIdentities[currentSlot][i] == _address) {
           return false;
         }
@@ -116,7 +117,7 @@ library ActiveBridgeSetLib {
     ActiveBridgeSet storage _abs,
     uint16 _currentSlot,
     uint16 _lastSlot,
-    bool _overflow) private returns (bool updated)
+    bool _overflow) private returns (bool)
   {
     // If there are more than `ACTIVITY_LENGTH` slots empty => remove entirely the ABS
     if (_overflow) {
@@ -149,7 +150,8 @@ library ActiveBridgeSetLib {
   /// @param _slot The slot to be flushed.
   function flushSlot(ActiveBridgeSet storage _abs, uint16 _slot) private {
     // For a given slot, go through all identities to flush them
-    for (uint16 id = 0; id < _abs.epochIdentities[_slot].length; id++) {
+    uint256 epochIdsLength = _abs.epochIdentities[_slot].length;
+    for (uint16 id = 0; id < epochIdsLength; id++) {
       flushIdentity(_abs, _abs.epochIdentities[_slot][id]);
     }
     delete _abs.epochIdentities[_slot];

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.3 <0.7.0;
 
 /**
  * @title Active Bridge Set (ABS) library
- * @notice This library counts the number of bridges that were active recently
+ * @notice This library counts the number of bridges that were active recently.
  */
 library ActiveBridgeSetLib {
 
@@ -117,7 +117,9 @@ library ActiveBridgeSetLib {
     ActiveBridgeSet storage _abs,
     uint16 _currentSlot,
     uint16 _lastSlot,
-    bool _overflow) private returns (bool)
+    bool _overflow)
+    private
+  returns (bool)
   {
     // If there are more than `ACTIVITY_LENGTH` slots empty => remove entirely the ABS
     if (_overflow) {

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 
 
 /**

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.5.3 <0.7.0;
 
 
 /**
- * @title A convenient wrapper around the `bytes memory` type that exposes a buffer-like interface.
+ * @title A convenient wrapper around the `bytes memory` type that exposes a buffer-like interface
  * @notice The buffer has an inner cursor that tracks the final offset of every read, i.e. any subsequent read will
  * start with the byte that goes right after the last one in the previous read.
  */

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -4,10 +4,16 @@ pragma experimental ABIEncoderV2;
 import "./BufferLib.sol";
 
 
-// TODO: add support for Array (majorType = 4)
-// TODO: add support for Map (majorType = 5)
-// TODO: add support for Float32 (majorType = 7, additionalInformation = 26)
-// TODO: add support for Float64 (majorType = 7, additionalInformation = 27)
+/**
+ * @title A minimalistic implementation of “RFC 7049 Concise Binary Object Representation”
+ * @notice This library leverages a buffer-like structure for step-by-step decoding of bytes so as to minimize
+ * the gas cost of decoding them into a useful native type.
+ * @dev Most of the logic has been borrowed from Patrick Gansterer’s cbor.js library: https://github.com/paroga/cbor-js
+ * TODO: add support for Array (majorType = 4)
+ * TODO: add support for Map (majorType = 5)
+ * TODO: add support for Float32 (majorType = 7, additionalInformation = 26)
+ * TODO: add support for Float64 (majorType = 7, additionalInformation = 27)
+ */
 library CBOR {
   using BufferLib for BufferLib.Buffer;
 

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -29,9 +29,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `bytes` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as a `bytes` value
+   * @notice Decode a `CBOR.Value` structure into a native `bytes` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as a `bytes` value.
    */
   function decodeBytes(Value memory _cborValue) public pure returns(bytes memory) {
     _cborValue.len = readLength(_cborValue.buffer, _cborValue.additionalInformation);
@@ -55,12 +55,12 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a `fixed16` value
+   * @notice Decode a `CBOR.Value` structure into a `fixed16` value.
    * @dev Due to the lack of support for floating or fixed point arithmetic in the EVM, this method offsets all values
    * by 5 decimal orders so as to get a fixed precision of 5 decimal positions, which should be OK for most `fixed16`
    * use cases. In other words, the output of this method is 10,000 times the actual value, encoded into an `int32`.
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `int128` value
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `int128` value.
    */
   function decodeFixed16(Value memory _cborValue) public pure returns(int32) {
     require(_cborValue.majorType == 7, "Tried to read a `fixed` value from a `CBOR.Value` with majorType != 7");
@@ -69,10 +69,10 @@ library CBOR {
   }
 
   /**
- * @notice Decode a `CBOR.Value` structure into a native `int128[]` value whose inner values follow the same convention
- * as explained in `decodeFixed16`
- * @param _cborValue An instance of `CBOR.Value`
- * @return The value represented by the input, as an `int128[]` value
+ * @notice Decode a `CBOR.Value` structure into a native `int128[]` value whose inner values follow the same convention.
+ * as explained in `decodeFixed16`.
+ * @param _cborValue An instance of `CBOR.Value`.
+ * @return The value represented by the input, as an `int128[]` value.
  */
   function decodeFixed16Array(Value memory _cborValue) public pure returns(int128[] memory) {
     require(_cborValue.majorType == 4, "Tried to read `int128[]` from a `CBOR.Value` with majorType != 4");
@@ -90,9 +90,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `int128` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `int128` value
+   * @notice Decode a `CBOR.Value` structure into a native `int128` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `int128` value.
    */
   function decodeInt128(Value memory _cborValue) public pure returns(int128) {
     if (_cborValue.majorType == 1) {
@@ -107,9 +107,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `int128[]` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `int128[]` value
+   * @notice Decode a `CBOR.Value` structure into a native `int128[]` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `int128[]` value.
    */
   function decodeInt128Array(Value memory _cborValue) public pure returns(int128[] memory) {
     require(_cborValue.majorType == 4, "Tried to read `int128[]` from a `CBOR.Value` with majorType != 4");
@@ -127,9 +127,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `string` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as a `string` value
+   * @notice Decode a `CBOR.Value` structure into a native `string` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as a `string` value.
    */
   function decodeString(Value memory _cborValue) public pure returns(string memory) {
     _cborValue.len = readLength(_cborValue.buffer, _cborValue.additionalInformation);
@@ -151,9 +151,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `string[]` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `string[]` value
+   * @notice Decode a `CBOR.Value` structure into a native `string[]` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `string[]` value.
    */
   function decodeStringArray(Value memory _cborValue) public pure returns(string[] memory) {
     require(_cborValue.majorType == 4, "Tried to read `string[]` from a `CBOR.Value` with majorType != 4");
@@ -171,9 +171,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `uint64` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `uint64` value
+   * @notice Decode a `CBOR.Value` structure into a native `uint64` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `uint64` value.
    */
   function decodeUint64(Value memory _cborValue) public pure returns(uint64) {
     require(_cborValue.majorType == 0, "Tried to read `uint64` from a `CBOR.Value` with majorType != 0");
@@ -181,9 +181,9 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a `CBOR.Value` structure into a native `uint64[]` value
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return The value represented by the input, as an `uint64[]` value
+   * @notice Decode a `CBOR.Value` structure into a native `uint64[]` value.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return The value represented by the input, as an `uint64[]` value.
    */
   function decodeUint64Array(Value memory _cborValue) public pure returns(uint64[] memory) {
     require(_cborValue.majorType == 4, "Tried to read `uint64[]` from a `CBOR.Value` with majorType != 4");
@@ -201,10 +201,10 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a CBOR.Value structure from raw bytes
-   * @dev This is the main factory for CBOR.Value instances, which can be later decoded into native EVM types
-   * @param _cborBytes Raw bytes representing a CBOR-encoded value
-   * @return A `CBOR.Value` instance containing a partially decoded value
+   * @notice Decode a CBOR.Value structure from raw bytes.
+   * @dev This is the main factory for CBOR.Value instances, which can be later decoded into native EVM types.
+   * @param _cborBytes Raw bytes representing a CBOR-encoded value.
+   * @return A `CBOR.Value` instance containing a partially decoded value.
    */
   function valueFromBytes(bytes memory _cborBytes) public pure returns(Value memory) {
     BufferLib.Buffer memory buffer = BufferLib.Buffer(_cborBytes, 0);
@@ -213,10 +213,10 @@ library CBOR {
   }
 
   /**
-   * @notice Decode a CBOR.Value structure from raw bytes
-   * @dev This is an alternate factory for CBOR.Value instances, which can be later decoded into native EVM types
-   * @param _buffer A Buffer structure representing a CBOR-encoded value
-   * @return A `CBOR.Value` instance containing a partially decoded value
+   * @notice Decode a CBOR.Value structure from raw bytes.
+   * @dev This is an alternate factory for CBOR.Value instances, which can be later decoded into native EVM types.
+   * @param _buffer A Buffer structure representing a CBOR-encoded value.
+   * @return A `CBOR.Value` instance containing a partially decoded value.
    */
   function valueFromBuffer(BufferLib.Buffer memory _buffer) public pure returns(Value memory) {
     require(_buffer.data.length > 0, "Found empty buffer when parsing CBOR value");

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.21 <0.6.0;
+pragma solidity >=0.4.21 <0.7.0;
 
 
 contract Migrations {

--- a/contracts/Request.sol
+++ b/contracts/Request.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.5.3 <0.7.0;
 
 
 /**
- * @title The serialized form of a Witnet data request.
+ * @title The serialized form of a Witnet data request
  */
 contract Request {
   bytes public bytecode;
@@ -14,7 +14,7 @@ contract Request {
   * the WRB should not be considered trustless before a valid Proof-of-Inclusion has been posted for the requests.
   * The hash of the request is computed in the constructor to guarantee consistency. Otherwise there could be a
   * mismatch and a data request could be resolved with the result of another.
-  * @param _bytecode Witnet request in bytes
+  * @param _bytecode Witnet request in bytes.
   */
   constructor(bytes memory _bytecode) public {
     bytecode = _bytecode;

--- a/contracts/Request.sol
+++ b/contracts/Request.sol
@@ -8,12 +8,14 @@ contract Request {
   bytes public bytecode;
   uint256 public id;
 
-  // A `Request` is constructed around a `bytes memory` value containing a well-formed Witnet data request serialized
-  // using Protocol Buffers. However, we cannot verify its validity at this point. This implies that contracts using
-  // the WRB should not be considered trustless before a valid Proof-of-Inclusion has been posted for the requests.
-  //
-  // The hash of the request is computed in the constructor to guarantee consistency. Otherwise there could be a
-  // mismatch and a data request could be resolved with the result of another.
+ /**
+  * @dev A `Request` is constructed around a `bytes memory` value containing a well-formed Witnet data request serialized
+  * using Protocol Buffers. However, we cannot verify its validity at this point. This implies that contracts using
+  * the WRB should not be considered trustless before a valid Proof-of-Inclusion has been posted for the requests.
+  * The hash of the request is computed in the constructor to guarantee consistency. Otherwise there could be a
+  * mismatch and a data request could be resolved with the result of another.
+  * @param _bytecode Witnet request in bytes
+  */
   constructor(bytes memory _bytecode) public {
     bytecode = _bytecode;
     id = uint256(sha256(_bytecode));

--- a/contracts/Request.sol
+++ b/contracts/Request.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 
 
 /**

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.4;
 
 
 /**

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,0 +1,151 @@
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+  /**
+   * @dev Returns the addition of two unsigned integers, reverting on
+   * overflow.
+   *
+   * Counterpart to Solidity's `+` operator.
+   *
+   * Requirements:
+   * - Addition cannot overflow.
+   */
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    require(c >= a, "SafeMath: addition overflow");
+
+    return c;
+  }
+
+  /**
+   * @dev Returns the subtraction of two unsigned integers, reverting on
+   * overflow (when the result is negative).
+   *
+   * Counterpart to Solidity's `-` operator.
+   *
+   * Requirements:
+   * - Subtraction cannot overflow.
+   */
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    return sub(a, b, "SafeMath: subtraction overflow");
+  }
+
+  /**
+   * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+   * overflow (when the result is negative).
+   *
+   * Counterpart to Solidity's `-` operator.
+   *
+   * Requirements:
+   * - Subtraction cannot overflow.
+   */
+  function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+    require(b <= a, errorMessage);
+    uint256 c = a - b;
+
+    return c;
+  }
+
+  /**
+   * @dev Returns the multiplication of two unsigned integers, reverting on
+   * overflow.
+   *
+   * Counterpart to Solidity's `*` operator.
+   *
+   * Requirements:
+   * - Multiplication cannot overflow.
+   */
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+    if (a == 0) {
+      return 0;
+    }
+
+    uint256 c = a * b;
+    require(c / a == b, "SafeMath: multiplication overflow");
+
+    return c;
+  }
+
+  /**
+   * @dev Returns the integer division of two unsigned integers. Reverts on
+   * division by zero. The result is rounded towards zero.
+   *
+   * Counterpart to Solidity's `/` operator. Note: this function uses a
+   * `revert` opcode (which leaves remaining gas untouched) while Solidity
+   * uses an invalid opcode to revert (consuming all remaining gas).
+   *
+   * Requirements:
+   * - The divisor cannot be zero.
+   */
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    return div(a, b, "SafeMath: division by zero");
+  }
+
+  /**
+   * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+   * division by zero. The result is rounded towards zero.
+   *
+   * Counterpart to Solidity's `/` operator. Note: this function uses a
+   * `revert` opcode (which leaves remaining gas untouched) while Solidity
+   * uses an invalid opcode to revert (consuming all remaining gas).
+   *
+   * Requirements:
+   * - The divisor cannot be zero.
+   */
+  function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+    // Solidity only automatically asserts when dividing by 0
+    require(b > 0, errorMessage);
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+    return c;
+  }
+
+  /**
+   * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+   * Reverts when dividing by zero.
+   *
+   * Counterpart to Solidity's `%` operator. This function uses a `revert`
+   * opcode (which leaves remaining gas untouched) while Solidity uses an
+   * invalid opcode to revert (consuming all remaining gas).
+   *
+   * Requirements:
+   * - The divisor cannot be zero.
+   */
+  function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+    return mod(a, b, "SafeMath: modulo by zero");
+  }
+
+  /**
+   * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+   * Reverts with custom message when dividing by zero.
+   *
+   * Counterpart to Solidity's `%` operator. This function uses a `revert`
+   * opcode (which leaves remaining gas untouched) while Solidity uses an
+   * invalid opcode to revert (consuming all remaining gas).
+   *
+   * Requirements:
+   * - The divisor cannot be zero.
+   */
+  function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+    require(b != 0, errorMessage);
+    return a % b;
+  }
+}

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -15,11 +15,11 @@ contract UsingWitnet {
 
   WitnetRequestsBoardProxy private wrb;
 
-  /**
+ /**
   * @notice Include an address to specify the WitnetRequestsBoard
   * @param _wrb WitnetRequestsBoard address
   */
-  constructor (address _wrb) public {
+  constructor(address _wrb) public {
     wrb = WitnetRequestsBoardProxy(_wrb);
   }
 

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -8,7 +8,7 @@ import "./WitnetRequestsBoardProxy.sol";
 /**
  * @title The UsingWitnet contract
  * @notice Contract writers can inherit this contract in order to create requests for the
- * Witnet network
+ * Witnet network.
  */
 contract UsingWitnet {
   using Witnet for Witnet.Result;
@@ -16,8 +16,8 @@ contract UsingWitnet {
   WitnetRequestsBoardProxy private wrb;
 
  /**
-  * @notice Include an address to specify the WitnetRequestsBoard
-  * @param _wrb WitnetRequestsBoard address
+  * @notice Include an address to specify the WitnetRequestsBoard.
+  * @param _wrb WitnetRequestsBoard address.
   */
   constructor(address _wrb) public {
     wrb = WitnetRequestsBoardProxy(_wrb);
@@ -31,22 +31,22 @@ contract UsingWitnet {
   }
 
   /**
-  * @notice Send a new request to the Witnet network
-  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
-  * @param _request An instance of the `Request` contract
-  * @param _tallyReward Reward specified for the user which post the Data Request result
-  * @return Sequencial identifier for the request included in the WitnetRequestsBoard
+  * @notice Send a new request to the Witnet network.
+  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract.
+  * @param _request An instance of the `Request` contract.
+  * @param _tallyReward Reward specified for the user which post the Data Request result.
+  * @return Sequencial identifier for the request included in the WitnetRequestsBoard.
   */
   function witnetPostRequest(Request _request, uint256 _tallyReward) internal returns (uint256) {
     return wrb.postDataRequest.value(msg.value)(_request.bytecode(), _tallyReward);
   }
 
   /**
-  * @notice Check if a request has been accepted into Witnet
-  * @dev Contracts depending on Witnet should not start their main business logic (e.g. receiving value from third
+  * @notice Check if a request has been accepted into Witnet.
+  * @dev Contracts depending on Witnet should not start their main business logic (e.g. receiving value from third.
   * parties) before this method returns `true`
-  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard
-  * @return A boolean telling if the request has been already accepted or not. `false` do not mean rejection, though
+  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard.
+  * @return A boolean telling if the request has been already accepted or not. `false` do not mean rejection, though.
   */
   function witnetCheckRequestAccepted(uint256 _id) internal view returns (bool) {
     // Find the request in the
@@ -57,20 +57,20 @@ contract UsingWitnet {
   }
 
   /**
-  * @notice Upgrade the rewards for a Data Request previously included
-  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract
-  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard
-  * @param _tallyReward Reward specified for the user which post the Data Request result
+  * @notice Upgrade the rewards for a Data Request previously included.
+  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract.
+  * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard.
+  * @param _tallyReward Reward specified for the user which post the Data Request result.
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) internal {
     wrb.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
   }
 
   /**
-  * @notice Read the result of a resolved request
-  * @dev Call to `read_result` function in the WitnetRequestsBoard contract
-  * @param _id The sequential identifier of a request that was posted to Witnet
-  * @return The result of the request as an instance of `Result`
+  * @notice Read the result of a resolved request.
+  * @dev Call to `read_result` function in the WitnetRequestsBoard contract.
+  * @param _id The sequential identifier of a request that was posted to Witnet.
+  * @return The result of the request as an instance of `Result`.
   */
   function witnetReadResult(uint256 _id) internal view returns (Witnet.Result memory) {
     return Witnet.resultFromCborBytes(wrb.readResult(_id));

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 
 import "./Request.sol";
 import "./Witnet.sol";
@@ -13,7 +13,7 @@ import "./WitnetRequestsBoardProxy.sol";
 contract UsingWitnet {
   using Witnet for Witnet.Result;
 
-  WitnetRequestsBoardProxy wrb;
+  WitnetRequestsBoardProxy private wrb;
 
   /**
   * @notice Include an address to specify the WitnetRequestsBoard
@@ -34,12 +34,11 @@ contract UsingWitnet {
   * @notice Send a new request to the Witnet network
   * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
   * @param _request An instance of the `Request` contract
-  * @param _requestReward Reward specified for the user which posts the request into Witnet
-  * @param _resultReward Reward specified for the user which posts back the request result
+  * @param _tallyReward Reward specified for the user which post the Data Request result
   * @return Sequencial identifier for the request included in the WitnetRequestsBoard
   */
-  function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward) internal returns (uint256 id) {
-    return wrb.postDataRequest.value(_requestReward + _resultReward)(_request.bytecode(), _resultReward);
+  function witnetPostRequest(Request _request, uint256 _tallyReward) internal returns (uint256) {
+    return wrb.postDataRequest.value(msg.value)(_request.bytecode(), _tallyReward);
   }
 
   /**

--- a/contracts/UsingWitnetBytes.sol
+++ b/contracts/UsingWitnetBytes.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 
 import "./WitnetRequestsBoardProxy.sol";
 
@@ -10,7 +10,7 @@ import "./WitnetRequestsBoardProxy.sol";
  */
 contract UsingWitnetBytes {
 
-  WitnetRequestsBoardProxy wrb;
+  WitnetRequestsBoardProxy private wrb;
 
   /**
   * @notice Include an address to specify the WitnetRequestsBoard
@@ -27,7 +27,7 @@ contract UsingWitnetBytes {
   * @param _tallyReward Reward specified for the user which post the Data Request result
   * @return Identifier for the Data Request included in the WitnetRequestsBoard
   */
-  function witnetPostRequest(bytes memory _requestBytes, uint256 _tallyReward) internal returns(uint256 id) {
+  function witnetPostRequest(bytes memory _requestBytes, uint256 _tallyReward) internal returns(uint256) {
     return wrb.postDataRequest.value(msg.value)(_requestBytes, _tallyReward);
   }
 

--- a/contracts/UsingWitnetBytes.sol
+++ b/contracts/UsingWitnetBytes.sol
@@ -16,7 +16,7 @@ contract UsingWitnetBytes {
   * @notice Include an address to specify the WitnetRequestsBoard
   * @param _wrb WitnetRequestsBoard address
   */
-  constructor (address _wrb) public {
+  constructor(address _wrb) public {
     wrb = WitnetRequestsBoardProxy(_wrb);
   }
 

--- a/contracts/UsingWitnetBytes.sol
+++ b/contracts/UsingWitnetBytes.sol
@@ -6,33 +6,33 @@ import "./WitnetRequestsBoardProxy.sol";
 /**
  * @title The UsingWitnet contract
  * @notice Contract writers can inherit this contract in order to create requests for the
- * Witnet network
+ * Witnet network.
  */
 contract UsingWitnetBytes {
 
   WitnetRequestsBoardProxy private wrb;
 
   /**
-  * @notice Include an address to specify the WitnetRequestsBoard
-  * @param _wrb WitnetRequestsBoard address
+  * @notice Include an address to specify the WitnetRequestsBoard.
+  * @param _wrb WitnetRequestsBoard address.
   */
   constructor(address _wrb) public {
     wrb = WitnetRequestsBoardProxy(_wrb);
   }
 
   /**
-  * @notice Include a new Data Request to be resolved by Witnet network
-  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
-  * @param _requestBytes Data Request bytes
-  * @param _tallyReward Reward specified for the user which post the Data Request result
-  * @return Identifier for the Data Request included in the WitnetRequestsBoard
+  * @notice Include a new Data Request to be resolved by Witnet network.
+  * @dev Call to `post_dr` function in the WitnetRequestsBoard contract.
+  * @param _requestBytes Data Request bytes.
+  * @param _tallyReward Reward specified for the user which post the Data Request result.
+  * @return Identifier for the Data Request included in the WitnetRequestsBoard.
   */
   function witnetPostRequest(bytes memory _requestBytes, uint256 _tallyReward) internal returns(uint256) {
     return wrb.postDataRequest.value(msg.value)(_requestBytes, _tallyReward);
   }
 
   /**
-  * @notice Check if a request has been accepted into Witnet
+  * @notice Check if a request has been accepted into Witnet.
   * @dev Contracts depending on Witnet should not start their main business logic (e.g. receiving value from third
   * parties) before this method returns `true`.
   * @param _id The id of a request that has been previously sent to the WitnetRequestsBoard.
@@ -47,20 +47,20 @@ contract UsingWitnetBytes {
   }
 
   /**
-  * @notice Upgrade the rewards for a Data Request previously included
-  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract
-  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard
-  * @param _tallyReward Reward specified for the user which post the Data Request result
+  * @notice Upgrade the rewards for a Data Request previously included.
+  * @dev Call to `upgrade_dr` function in the WitnetRequestsBoard contract.
+  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard.
+  * @param _tallyReward Reward specified for the user which post the Data Request result.
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) internal {
     wrb.upgradeDataRequest.value(msg.value)(_id, _tallyReward);
   }
 
   /**
-  * @notice Read the result of a resolved Data Request
-  * @dev Call to `read_result` function in the WitnetRequestsBoard contract
-  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard
-  * @return Data Request result
+  * @notice Read the result of a resolved Data Request.
+  * @dev Call to `read_result` function in the WitnetRequestsBoard contract.
+  * @param _id Identifier for the Data Request included in the WitnetRequestsBoard.
+  * @return Data Request result.
   */
   function witnetReadResult (uint256 _id) internal view returns(bytes memory) {
     return wrb.readResult(_id);

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -5,6 +5,11 @@ import "./BufferLib.sol";
 import "./CBOR.sol";
 
 
+/**
+ * @title A library for decoding Witnet request results
+ * @notice The library exposes functions to check the Witnet request success
+ * and retrieve Witnet results from CBOR values into solidity types.
+ */
 library Witnet {
   using CBOR for CBOR.Value;
 
@@ -115,11 +120,21 @@ library Witnet {
   Result impl's
   */
 
+ /**
+   * @notice Decode raw CBOR bytes into a Result instance
+   * @param _cborBytes Raw bytes representing a CBOR-encoded value
+   * @return A `Result` instance
+   */
   function resultFromCborBytes(bytes calldata _cborBytes) external pure returns(Result memory) {
     CBOR.Value memory cborValue = CBOR.valueFromBytes(_cborBytes);
     return resultFromCborValue(cborValue);
   }
 
+ /**
+   * @notice Decode a CBOR value into a Result instance
+   * @param _cborValue An instance of `CBOR.Value`
+   * @return A `Result` instance
+   */
   function resultFromCborValue(CBOR.Value memory _cborValue) public pure returns(Result memory) {
     // Witnet uses CBOR tag 39 to represent RADON error code identifiers.
     // [CBOR tag 39] Identifiers for CBOR: https://github.com/lucas-clemente/cbor-specs/blob/master/id.md

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -7,7 +7,7 @@ import "./CBOR.sol";
 
 /**
  * @title A library for decoding Witnet request results
- * @notice The library exposes functions to check the Witnet request success
+ * @notice The library exposes functions to check the Witnet request success.
  * and retrieve Witnet results from CBOR values into solidity types.
  */
 library Witnet {
@@ -121,9 +121,9 @@ library Witnet {
   */
 
  /**
-   * @notice Decode raw CBOR bytes into a Result instance
-   * @param _cborBytes Raw bytes representing a CBOR-encoded value
-   * @return A `Result` instance
+   * @notice Decode raw CBOR bytes into a Result instance.
+   * @param _cborBytes Raw bytes representing a CBOR-encoded value.
+   * @return A `Result` instance.
    */
   function resultFromCborBytes(bytes calldata _cborBytes) external pure returns(Result memory) {
     CBOR.Value memory cborValue = CBOR.valueFromBytes(_cborBytes);
@@ -131,9 +131,9 @@ library Witnet {
   }
 
  /**
-   * @notice Decode a CBOR value into a Result instance
-   * @param _cborValue An instance of `CBOR.Value`
-   * @return A `Result` instance
+   * @notice Decode a CBOR value into a Result instance.
+   * @param _cborValue An instance of `CBOR.Value`.
+   * @return A `Result` instance.
    */
   function resultFromCborValue(CBOR.Value memory _cborValue) public pure returns(Result memory) {
     // Witnet uses CBOR tag 39 to represent RADON error code identifiers.
@@ -143,26 +143,26 @@ library Witnet {
   }
 
   /**
-   * @notice Tell if a Result is successful
-   * @param _result An instance of Result
-   * @return `true` if successful, `false` if errored
+   * @notice Tell if a Result is successful.
+   * @param _result An instance of Result.
+   * @return `true` if successful, `false` if errored.
    */
   function isOk(Result memory _result) public pure returns(bool) {
     return _result.success;
   }
 
   /**
-   * @notice Tell if a Result is errored
-   * @param _result An instance of Result
-   * @return `true` if errored, `false` if successful
+   * @notice Tell if a Result is errored.
+   * @param _result An instance of Result.
+   * @return `true` if errored, `false` if successful.
    */
   function isError(Result memory _result) public pure returns(bool) {
     return !_result.success;
   }
 
   /**
-   * @notice Decode a bytes value from a Result as a `bytes` value
-   * @param _result An instance of Result
+   * @notice Decode a bytes value from a Result as a `bytes` value.
+   * @param _result An instance of Result.
    * @return The `bytes` decoded from the Result.
    */
   function asBytes(Result memory _result) public pure returns(bytes memory) {
@@ -171,9 +171,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode an error code from a Result as a member of `ErrorCodes`
-   * @param _result An instance of `Result`
-   * @return The `CBORValue.Error memory` decoded from the Result
+   * @notice Decode an error code from a Result as a member of `ErrorCodes`.
+   * @param _result An instance of `Result`.
+   * @return The `CBORValue.Error memory` decoded from the Result.
    */
   function asErrorCode(Result memory _result) public pure returns(ErrorCodes) {
     uint64[] memory error = asRawError(_result);
@@ -187,8 +187,8 @@ library Witnet {
   }
 
   /**
-   * @notice Generate a suitable error message for a member of `ErrorCodes` and its corresponding arguments
-   * @param _result An instance of `Result`
+   * @notice Generate a suitable error message for a member of `ErrorCodes` and its corresponding arguments.
+   * @param _result An instance of `Result`.
    * @return A tuple containing the `CBORValue.Error memory` decoded from the `Result`, plus a loggable error message.
    */
   function asErrorMessage(Result memory _result) public pure returns(ErrorCodes, string memory) {
@@ -292,9 +292,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode a raw error from a `Result` as a `uint64[]`
-   * @param _result An instance of `Result`
-   * @return The `uint64[]` raw error as decoded from the `Result`
+   * @notice Decode a raw error from a `Result` as a `uint64[]`.
+   * @param _result An instance of `Result`.
+   * @return The `uint64[]` raw error as decoded from the `Result`.
    */
   function asRawError(Result memory _result) public pure returns(uint64[] memory) {
     require(!_result.success, "Tried to read error code from successful Result");
@@ -302,12 +302,12 @@ library Witnet {
   }
 
   /**
-   * @notice Decode a fixed16 (half-precision) numeric value from a Result as an `int32` value
-   * @dev Due to the lack of support for floating or fixed point arithmetic in the EVM, this method offsets all values
-   * by 5 decimal orders so as to get a fixed precision of 5 decimal positions, which should be OK for most `fixed16`
+   * @notice Decode a fixed16 (half-precision) numeric value from a Result as an `int32` value.
+   * @dev Due to the lack of support for floating or fixed point arithmetic in the EVM, this method offsets all values.
+   * by 5 decimal orders so as to get a fixed precision of 5 decimal positions, which should be OK for most `fixed16`.
    * use cases. In other words, the output of this method is 10,000 times the actual value, encoded into an `int32`.
-   * @param _result An instance of Result
-   * @return The `int128` decoded from the Result
+   * @param _result An instance of Result.
+   * @return The `int128` decoded from the Result.
    */
   function asFixed16(Result memory _result) public pure returns(int32) {
     require(_result.success, "Tried to read `fixed16` value from errored Result");
@@ -315,9 +315,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode an array of fixed16 values from a Result as an `int128[]` value
-   * @param _result An instance of Result
-   * @return The `int128[]` decoded from the Result
+   * @notice Decode an array of fixed16 values from a Result as an `int128[]` value.
+   * @param _result An instance of Result.
+   * @return The `int128[]` decoded from the Result.
    */
   function asFixed16Array(Result memory _result) public pure returns(int128[] memory) {
     require(_result.success, "Tried to read `fixed16[]` value from errored Result");
@@ -325,9 +325,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode a integer numeric value from a Result as an `int128` value
-   * @param _result An instance of Result
-   * @return The `int128` decoded from the Result
+   * @notice Decode a integer numeric value from a Result as an `int128` value.
+   * @param _result An instance of Result.
+   * @return The `int128` decoded from the Result.
    */
   function asInt128(Result memory _result) public pure returns(int128) {
     require(_result.success, "Tried to read `int128` value from errored Result");
@@ -335,9 +335,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode an array of integer numeric values from a Result as an `int128[]` value
-   * @param _result An instance of Result
-   * @return The `int128[]` decoded from the Result
+   * @notice Decode an array of integer numeric values from a Result as an `int128[]` value.
+   * @param _result An instance of Result.
+   * @return The `int128[]` decoded from the Result.
    */
   function asInt128Array(Result memory _result) public pure returns(int128[] memory) {
     require(_result.success, "Tried to read `int128[]` value from errored Result");
@@ -345,9 +345,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode a string value from a Result as a `string` value
-   * @param _result An instance of Result
-   * @return The `string` decoded from the Result
+   * @notice Decode a string value from a Result as a `string` value.
+   * @param _result An instance of Result.
+   * @return The `string` decoded from the Result.
    */
   function asString(Result memory _result) public pure returns(string memory) {
     require(_result.success, "Tried to read `string` value from errored Result");
@@ -355,9 +355,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode an array of string values from a Result as a `string[]` value
-   * @param _result An instance of Result
-   * @return The `string[]` decoded from the Result
+   * @notice Decode an array of string values from a Result as a `string[]` value.
+   * @param _result An instance of Result.
+   * @return The `string[]` decoded from the Result.
    */
   function asStringArray(Result memory _result) public pure returns(string[] memory) {
     require(_result.success, "Tried to read `string[]` value from errored Result");
@@ -365,9 +365,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode a natural numeric value from a Result as a `uint64` value
-   * @param _result An instance of Result
-   * @return The `uint64` decoded from the Result
+   * @notice Decode a natural numeric value from a Result as a `uint64` value.
+   * @param _result An instance of Result.
+   * @return The `uint64` decoded from the Result.
    */
   function asUint64(Result memory _result) public pure returns(uint64) {
     require(_result.success, "Tried to read `uint64` value from errored Result");
@@ -375,9 +375,9 @@ library Witnet {
   }
 
   /**
-   * @notice Decode an array of natural numeric values from a Result as a `uint64[]` value
-   * @param _result An instance of Result
-   * @return The `uint64[]` decoded from the Result
+   * @notice Decode an array of natural numeric values from a Result as a `uint64[]` value.
+   * @param _result An instance of Result.
+   * @return The `uint64[]` decoded from the Result.
    */
   function asUint64Array(Result memory _result) public pure returns(uint64[] memory) {
     require(_result.success, "Tried to read `uint64[]` value from errored Result");
@@ -385,9 +385,9 @@ library Witnet {
   }
 
   /**
-   * @notice Convert a stage index number into the name of the matching Witnet request stage
-   * @param _stageIndex A `uint64` identifying the index of one of the Witnet request stages
-   * @return The name of the matching stage
+   * @notice Convert a stage index number into the name of the matching Witnet request stage.
+   * @param _stageIndex A `uint64` identifying the index of one of the Witnet request stages.
+   * @return The name of the matching stage.
    */
   function stageName(uint64 _stageIndex) public pure returns(string memory) {
     if (_stageIndex == 0) {
@@ -402,10 +402,10 @@ library Witnet {
   }
 
   /**
-   * @notice Convert a `uint64` into a 1, 2 or 3 characters long `string` representing its
-   * three less significant decimal values
-   * @param _u A `uint64` value
-   * @return The `string` representing its decimal value
+   * @notice Convert a `uint64` into a 1, 2 or 3 characters long `string` representing its.
+   * three less significant decimal values.
+   * @param _u A `uint64` value.
+   * @return The `string` representing its decimal value.
    */
   function utoa(uint64 _u) private pure returns(string memory) {
     if (_u < 10) {
@@ -427,9 +427,9 @@ library Witnet {
   }
 
   /**
- * @notice Convert a `uint64` into a 2 characters long `string` representing its two less significant hexadecimal values
- * @param _u A `uint64` value
- * @return The `string` representing its hexadecimal value
+ * @notice Convert a `uint64` into a 2 characters long `string` representing its two less significant hexadecimal values.
+ * @param _u A `uint64` value.
+ * @return The `string` representing its hexadecimal value.
  */
   function utohex(uint64 _u) private pure returns(string memory) {
     bytes memory b2 = new bytes(2);

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.3 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./BufferLib.sol";
@@ -115,16 +115,16 @@ library Witnet {
   Result impl's
   */
 
+  function resultFromCborBytes(bytes calldata _cborBytes) external pure returns(Result memory) {
+    CBOR.Value memory cborValue = CBOR.valueFromBytes(_cborBytes);
+    return resultFromCborValue(cborValue);
+  }
+
   function resultFromCborValue(CBOR.Value memory _cborValue) public pure returns(Result memory) {
     // Witnet uses CBOR tag 39 to represent RADON error code identifiers.
     // [CBOR tag 39] Identifiers for CBOR: https://github.com/lucas-clemente/cbor-specs/blob/master/id.md
     bool success = _cborValue.tag != 39;
     return Result(success, _cborValue);
-  }
-
-  function resultFromCborBytes(bytes memory _cborBytes) public pure returns(Result memory) {
-    CBOR.Value memory cborValue = CBOR.valueFromBytes(_cborBytes);
-    return resultFromCborValue(cborValue);
   }
 
   /**

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -9,7 +9,7 @@ import "./WitnetRequestsBoardInterface.sol";
 
 /**
  * @title Witnet Requests Board
- * @notice Contract to bridge requests to Witnet
+ * @notice Contract to bridge requests to Witnet.
  * @dev This contract enables posting requests that Witnet bridges will insert into the Witnet network.
  * The result of the requests will be posted back to this contract by the bridge nodes too.
  * @author Witnet Foundation
@@ -119,9 +119,9 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   }
 
  /**
-  * @notice Include an address to specify the Witnet Block Relay and a replication factor
-  * @param _blockRelayAddress BlockRelayProxy address
-  * @param _repFactor replication factor
+  * @notice Include an address to specify the Witnet Block Relay and a replication factor.
+  * @param _blockRelayAddress BlockRelayProxy address.
+  * @param _repFactor replication factor.
   */
   constructor(address _blockRelayAddress, uint8 _repFactor) public {
     blockRelay = BlockRelayProxy(_blockRelayAddress);
@@ -263,9 +263,9 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     return requests[_id].result;
   }
 
-  /// @dev Retrieves hash of the data request transaction in Witnet
+  /// @dev Retrieves hash of the data request transaction in Witnet.
   /// @param _id The unique identifier of the data request.
-  /// @return The hash of the DataRequest transaction in Witnet
+  /// @return The hash of the DataRequest transaction in Witnet.
   function readDrHash(uint256 _id) external view override returns(uint256) {
     return requests[_id].drHash;
   }
@@ -276,48 +276,48 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     return requests.length;
   }
 
-  /// @dev Get the current ABS count
-  /// @return number of distinct identities on the ABS
+  /// @dev Get the current ABS count.
+  /// @return number of distinct identities on the ABS.
   function absCount() external view returns (uint32) {
     return abs.activeIdentities;
   }
 
-  /// @dev Checks if an identity is member of the ABS
-  /// @return true if the identity is part of the ABS
+  /// @dev Checks if an identity is member of the ABS.
+  /// @return true if the identity is part of the ABS.
   function isABSMember(address _address) external view returns (bool) {
     return abs.absMembership(_address);
   }
 
-  /// @dev Wrapper around the decodeProof from VRF library
-  /// @dev Decode VRF proof from bytes
-  /// @param _proof The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
-  /// @return The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
+  /// @notice Wrapper around the decodeProof from VRF library.
+  /// @dev Decode VRF proof from bytes.
+  /// @param _proof The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`.
+  /// @return The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`.
   function decodeProof(bytes calldata _proof) external pure returns (uint[4] memory) {
     return VRF.decodeProof(_proof);
   }
 
-  /// @dev Wrapper around the decodePoint from VRF library
-  /// @dev Decode EC point from bytes
-  /// @param _point The EC point as bytes
-  /// @return The point as `[point-x, point-y]`
+  /// @notice Wrapper around the decodePoint from VRF library.
+  /// @dev Decode EC point from bytes.
+  /// @param _point The EC point as bytes.
+  /// @return The point as `[point-x, point-y]`.
   function decodePoint(bytes calldata _point) external pure returns (uint[2] memory) {
     return VRF.decodePoint(_point);
   }
 
-  /// @dev Wrapper around the computeFastVerifyParams from VRF library
-  /// @dev Compute the parameters (EC points) required for the VRF fast verification function.
-  /// @param _publicKey The public key as an array composed of `[pubKey-x, pubKey-y]`
-  /// @param _proof The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
-  /// @param _message The message (in bytes) used for computing the VRF
-  /// @return The fast verify required parameters as the tuple `([uPointX, uPointY], [sHX, sHY, cGammaX, cGammaY])`
+  /// @dev Wrapper around the computeFastVerifyParams from VRF library.
+  /// @dev Compute the parameters (EC points) required for the VRF fast verification function..
+  /// @param _publicKey The public key as an array composed of `[pubKey-x, pubKey-y]`.
+  /// @param _proof The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`.
+  /// @param _message The message (in bytes) used for computing the VRF.
+  /// @return The fast verify required parameters as the tuple `([uPointX, uPointY], [sHX, sHY, cGammaX, cGammaY])`.
   function computeFastVerifyParams(uint256[2] calldata _publicKey, uint256[4] calldata _proof, bytes calldata _message)
     external pure returns (uint256[2] memory, uint256[4] memory)
   {
     return VRF.computeFastVerifyParams(_publicKey, _proof, _message);
   }
 
-  /// @dev Updates the ABS activity with the block number provided
-  /// @param _blockNumber update the ABS until this block number
+  /// @dev Updates the ABS activity with the block number provided.
+  /// @param _blockNumber update the ABS until this block number.
   function updateAbsActivity(uint256 _blockNumber) external {
     require (_blockNumber >= abs.lastBlockNumber, "The last block number updated was higher than the one provided");
     require (_blockNumber <= block.number, "The block number provided has not been reached");
@@ -325,8 +325,8 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     abs.updateActivity(_blockNumber);
   }
 
-  /// @dev Verifies if the contract is upgradable
-  /// @return true if the contract upgradable
+  /// @dev Verifies if the contract is upgradable.
+  /// @return true if the contract upgradable.
   function isUpgradable(address _address) external view override returns(bool) {
     if (_address == witnet) {
       return true;
@@ -334,11 +334,11 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     return false;
   }
 
-  /// @dev Claim drs to be posted to Witnet by the node
-  /// @param _ids Data request ids to be claimed
-  /// @param _poe PoE claiming eligibility
-  /// @param _uPoint uPoint coordinates as [uPointX, uPointY] corresponding to U = s*B - c*Y
-  /// @param _vPointHelpers helpers for calculating the V point as [(s*H)X, (s*H)Y, cGammaX, cGammaY]. V = s*H + cGamma
+  /// @dev Claim drs to be posted to Witnet by the node.
+  /// @param _ids Data request ids to be claimed.
+  /// @param _poe PoE claiming eligibility.
+  /// @param _uPoint uPoint coordinates as [uPointX, uPointY] corresponding to U = s*B - c*Y.
+  /// @param _vPointHelpers helpers for calculating the V point as [(s*H)X, (s*H)Y, cGammaX, cGammaY]. V = s*H + cGamma.
   function claimDataRequests(
     uint256[] memory _ids,
     uint256[4] memory _poe,
@@ -362,17 +362,17 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     return true;
   }
 
-  /// @dev Read the beacon of the last block inserted
-  /// @return bytes to be signed by the node as PoE
+  /// @dev Read the beacon of the last block inserted.
+  /// @return bytes to be signed by the node as PoE.
   function getLastBeacon() public view virtual returns(bytes memory) {
     return blockRelay.getLastBeacon();
   }
 
-  /// @dev Claim drs to be posted to Witnet by the node
-  /// @param _poe PoE claiming eligibility
-  /// @param _publicKey The public key as an array composed of `[pubKey-x, pubKey-y]`
-  /// @param _uPoint uPoint coordinates as [uPointX, uPointY] corresponding to U = s*B - c*Y
-  /// @param _vPointHelpers helpers for calculating the V point as [(s*H)X, (s*H)Y, cGammaX, cGammaY]. V = s*H + cGamma
+  /// @dev Claim drs to be posted to Witnet by the node.
+  /// @param _poe PoE claiming eligibility.
+  /// @param _publicKey The public key as an array composed of `[pubKey-x, pubKey-y]`.
+  /// @param _uPoint uPoint coordinates as [uPointX, uPointY] corresponding to U = s*B - c*Y.
+  /// @param _vPointHelpers helpers for calculating the V point as [(s*H)X, (s*H)Y, cGammaX, cGammaY]. V = s*H + cGamma.
   function verifyPoe(
     uint256[4] memory _poe,
     uint256[2] memory _publicKey,
@@ -396,11 +396,11 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     return false;
   }
 
-  /// @dev Verifies the validity of a signature
-  /// @param _message message to be verified
-  /// @param _publicKey public key of the signer as `[pubKey-x, pubKey-y]`
-  /// @param _addrSignature the signature to verify asas r||s||v
-  /// @return true or false depending the validity
+  /// @dev Verifies the validity of a signature.
+  /// @param _message message to be verified.
+  /// @param _publicKey public key of the signer as `[pubKey-x, pubKey-y]`.
+  /// @param _addrSignature the signature to verify asas r||s||v.
+  /// @return true or false depending the validity.
   function verifySig(
     bytes memory _message,
     uint256[2] memory _publicKey,

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.6.4;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "./ActiveBridgeSetLib.sol";
 import "witnet-ethereum-block-relay/contracts/BlockRelayProxy.sol";

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -1,4 +1,6 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.21 <0.7.0;
+
+
 /**
  * @title Witnet Requests Board Interface
  * @notice Interface of a Witnet Request Board (WRB)
@@ -13,25 +15,17 @@ interface WitnetRequestsBoardInterface {
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
-    external
-    payable
-    returns(uint256);
+  function postDataRequest(bytes calldata _dr, uint256 _tallyReward) external payable returns(uint256);
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
-    external
-    payable;
+  function upgradeDataRequest(uint256 _id, uint256 _tallyReward) external payable;
 
   /// @dev Retrieves the DR hash of the id from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DR
-  function readDrHash (uint256 _id)
-    external
-    view
-    returns(uint256);
+  function readDrHash (uint256 _id) external view returns(uint256);
 
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -33,8 +33,8 @@ interface WitnetRequestsBoardInterface {
   /// @return The result of the DR
   function readResult (uint256 _id) external view returns(bytes memory);
 
-  /// @notice Verifies if the block relay can be upgraded
-  /// @return true if contract is upgradable
+  /// @notice Verifies if the block relay can be upgraded.
+  /// @return true if contract is upgradable.
   function isUpgradable(address _address) external view returns(bool);
 
 }

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -37,5 +37,4 @@ interface WitnetRequestsBoardInterface {
   /// @return true if contract is upgradable
   function isUpgradable(address _address) external view returns(bool);
 
-
 }

--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -5,7 +5,7 @@ import "./WitnetRequestsBoardInterface.sol";
 
 /**
  * @title Block Relay Proxy
- * @notice Contract to act as a proxy between the Witnet Bridge Interface and the Block Relay
+ * @notice Contract to act as a proxy between the Witnet Bridge Interface and the Block Relay.
  * @author Witnet Foundation
  */
 contract WitnetRequestsBoardProxy {
@@ -36,8 +36,8 @@ contract WitnetRequestsBoardProxy {
   }
 
  /**
-  * @notice Include an address to specify the Witnet Request Board
-  * @param _witnetRequestsBoardAddress WitnetRequestBoard address
+  * @notice Include an address to specify the Witnet Request Board.
+  * @param _witnetRequestsBoardAddress WitnetRequestBoard address.
   */
   constructor(address _witnetRequestsBoardAddress) public {
     // Initialize the first epoch pointing to the first controller
@@ -70,7 +70,7 @@ contract WitnetRequestsBoardProxy {
 
   /// @dev Retrieves the DR hash of the id from the WRB.
   /// @param _id The unique identifier of the data request.
-  /// @return The hash of the DR
+  /// @return The hash of the DR.
   function readDrHash (uint256 _id)
     external
     view
@@ -89,7 +89,7 @@ contract WitnetRequestsBoardProxy {
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
-  /// @return The result of the DR
+  /// @return The result of the DR.
   function readResult(uint256 _id) external view returns(bytes memory) {
     // Get the address and the offset of the corresponding to id
     address wrbAddress;
@@ -101,8 +101,8 @@ contract WitnetRequestsBoardProxy {
     return wrbWithResult.readResult(_id - offSetWrb);
   }
 
-  /// @notice Upgrades the Witnet Requests Board if the current one is upgradeable
-  /// @param _newAddress address of the new block relay to upgrade
+  /// @notice Upgrades the Witnet Requests Board if the current one is upgradeable.
+  /// @param _newAddress address of the new block relay to upgrade.
   function upgradeWitnetRequestsBoard(address _newAddress) public notIdentical(_newAddress) {
     // Require the WRB is upgradable
     require(witnetRequestsBoardInstance.isUpgradable(msg.sender), "The upgrade has been rejected by the current implementation");
@@ -113,8 +113,8 @@ contract WitnetRequestsBoardProxy {
     witnetRequestsBoardInstance = WitnetRequestsBoardInterface(_newAddress);
   }
 
-  /// @notice Gets the controller from an Id
-  /// @param _id id of a Data Request from which we get the controller
+  /// @notice Gets the controller from an Id.
+  /// @param _id id of a Data Request from which we get the controller.
   function getController(uint256 _id) internal view returns(address _controllerAddress, uint256 _offset) {
     uint256 n = controllers.length;
     // If the id is bigger than the lastId of a Controller, read the result in that Controller

--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "./WitnetRequestsBoardInterface.sol";
 
@@ -110,8 +110,6 @@ contract WitnetRequestsBoardProxy {
   function upgradeWitnetRequestsBoard(address _newAddress) public notIdentical(_newAddress) {
     // Require the WRB is upgradable
     require(witnetRequestsBoardInstance.isUpgradable(msg.sender), "The upgrade has been rejected by the current implementation");
-    // Set the offSet for the next WRB
-    uint256 n = controllers.length;
     // Map the currentLastId to the corresponding witnetRequestsBoardAddress and add it to controllers
     controllers.push(ControllerInfo({controllerAddress: _newAddress, lastId: currentLastId}));
     // Upgrade the WRB

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -5,7 +5,7 @@ import "witnet-ethereum-block-relay/contracts/BlockRelayInterface.sol";
 
 /**
  * @title Block relay contract
- * @notice Contract to store/read block headers from the Witnet network
+ * @notice Contract to store/read block headers from the Witnet network.
  * @author Witnet Foundation
  */
 contract MockBlockRelay is BlockRelayInterface {
@@ -46,7 +46,7 @@ contract MockBlockRelay is BlockRelayInterface {
     _;
   }
 
-   // Ensures block does not exist
+  // Ensures block does not exist
   modifier blockDoesNotExist(uint256 _id){
     require(blocks[_id].drHashMerkleRoot==0, "The block already existed");
     _;
@@ -57,8 +57,8 @@ contract MockBlockRelay is BlockRelayInterface {
     witnet = msg.sender;
   }
 
-  /// @dev Read the beacon of the last block inserted
-  /// @return bytes to be signed by bridge nodes
+  /// @dev Read the beacon of the last block inserted.
+  /// @return bytes to be signed by bridge nodes.
   function getLastBeacon()
     external
     view
@@ -69,23 +69,23 @@ contract MockBlockRelay is BlockRelayInterface {
   }
 
   /// @notice Returns the lastest epoch reported to the block relay.
-  /// @return epoch
+  /// @return the last epoch.
   function getLastEpoch() external view override returns(uint256) {
     return lastBlock.epoch;
   }
 
-  /// @notice Returns the latest hash reported to the block relay
-  /// @return blockhash
+  /// @notice Returns the latest hash reported to the block relay.
+  /// @return the last block hash.
   function getLastHash() external view override returns(uint256) {
     return lastBlock.blockHash;
   }
 
-  /// @dev Verifies the validity of a PoI against the DR merkle root
-  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
-  /// @param _blockHash the blockHash
-  /// @param _index the index in the merkle tree of the element to verify
-  /// @param _element the leaf to be verified
-  /// @return true or false depending the validity
+  /// @dev Verifies the validity of a PoI against the DR merkle root.
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..].
+  /// @param _blockHash the blockHash.
+  /// @param _index the index in the merkle tree of the element to verify.
+  /// @param _element the leaf to be verified.
+  /// @return true or false depending the validity.
   function verifyDrPoi(
     uint256[] calldata _poi,
     uint256 _blockHash,
@@ -105,12 +105,12 @@ contract MockBlockRelay is BlockRelayInterface {
       _element));
   }
 
-  /// @dev Verifies the validity of a PoI against the tally merkle root
-  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
-  /// @param _blockHash the blockHash
-  /// @param _index the index in the merkle tree of the element to verify
-  /// @param _element the element
-  /// @return true or false depending the validity
+  /// @dev Verifies the validity of a PoI against the tally merkle root.
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..].
+  /// @param _blockHash the blockHash.
+  /// @param _index the index in the merkle tree of the element to verify.
+  /// @param _element the element.
+  /// @return true or false depending the validity.
   function verifyTallyPoi(
     uint256[] calldata _poi,
     uint256 _blockHash,
@@ -130,17 +130,17 @@ contract MockBlockRelay is BlockRelayInterface {
       _element));
   }
 
-  /// @dev Determines if the contract is upgradable
-  /// @return true
+  /// @dev Determines if the contract is upgradable.
+  /// @return true if the contract is upgradable.
   function isUpgradable(address) external view override returns(bool) {
     return true;
   }
 
-  /// @dev Post new block into the block relay
-  /// @param _blockHash Hash of the block header
-  /// @param _epoch Witnet epoch to which the block belongs to
-  /// @param _drMerkleRoot Merkle root belonging to the data requests
-  /// @param _tallyMerkleRoot Merkle root belonging to the tallies
+  /// @dev Post new block into the block relay.
+  /// @param _blockHash Hash of the block header.
+  /// @param _epoch Witnet epoch to which the block belongs to.
+  /// @param _drMerkleRoot Merkle root belonging to the data requests.
+  /// @param _tallyMerkleRoot Merkle root belonging to the tallies.
   function postNewBlock(
     uint256 _blockHash,
     uint256 _epoch,
@@ -159,7 +159,7 @@ contract MockBlockRelay is BlockRelayInterface {
   }
 
   /// @dev Retrieve the requests-only merkle root hash that was reported for a specific block header.
-  /// @param _blockHash Hash of the block header
+  /// @param _blockHash Hash of the block header.
   /// @return Requests-only merkle root hash in the block header.
   function readDrMerkleRoot(uint256 _blockHash)
     external
@@ -171,7 +171,7 @@ contract MockBlockRelay is BlockRelayInterface {
   }
 
   /// @dev Retrieve the tallies-only merkle root hash that was reported for a specific block header.
-  /// @param _blockHash Hash of the block header
+  /// @param _blockHash Hash of the block header.
   /// tallies-only merkle root hash in the block header.
   function readTallyMerkleRoot(uint256 _blockHash)
     external
@@ -182,12 +182,12 @@ contract MockBlockRelay is BlockRelayInterface {
     return blocks[_blockHash].tallyHashMerkleRoot;
   }
 
-  /// @dev Verifies the validity of a PoI
-  /// @param _poi the proof of inclusion as [sibling1, sibling2,..]
-  /// @param _root the merkle root
-  /// @param _index the index in the merkle tree of the element to verify
-  /// @param _element the leaf to be verified
-  /// @return true or false depending the validity
+  /// @dev Verifies the validity of a PoI.
+  /// @param _poi the proof of inclusion as [sibling1, sibling2,..].
+  /// @param _root the merkle root.
+  /// @param _index the index in the merkle tree of the element to verify.
+  /// @param _element the leaf to be verified.
+  /// @return true or false depending the validity.
   function verifyPoi(
     uint256[] memory _poi,
     uint256 _root,
@@ -197,8 +197,8 @@ contract MockBlockRelay is BlockRelayInterface {
   {
     uint256 tree = _element;
     uint256 index = _index;
-    // We want to prove that the hash of the _poi and the _element is equal to _root
-    // For knowing if concatenate to the left or the right we check the parity of the the index
+    // We want to prove that the hash of the _poi and the _element is equal to _root.
+    // For knowing if concatenate to the left or the right we check the parity of the the index.
     for (uint i = 0; i < _poi.length; i++) {
       if (index%2 == 0) {
         tree = uint256(sha256(abi.encodePacked(tree, _poi[i])));

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -91,10 +91,10 @@ contract MockBlockRelay is BlockRelayInterface {
     uint256 _blockHash,
     uint256 _index,
     uint256 _element)
-  external
-  view
-  blockExists(_blockHash)
-  override
+    external
+    view
+    blockExists(_blockHash)
+    override
   returns(bool)
   {
     uint256 drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
@@ -116,10 +116,10 @@ contract MockBlockRelay is BlockRelayInterface {
     uint256 _blockHash,
     uint256 _index,
     uint256 _element)
-  external
-  view
-  blockExists(_blockHash)
-  override
+    external
+    view
+    blockExists(_blockHash)
+    override
   returns(bool)
   {
     uint256 tallyMerkleRoot = blocks[_blockHash].tallyHashMerkleRoot;

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -1,13 +1,13 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
+
 import "witnet-ethereum-block-relay/contracts/BlockRelayInterface.sol";
+
 
 /**
  * @title Block relay contract
  * @notice Contract to store/read block headers from the Witnet network
  * @author Witnet Foundation
  */
-
-
 contract MockBlockRelay is BlockRelayInterface {
 
   struct MerkleRoots {
@@ -25,7 +25,7 @@ contract MockBlockRelay is BlockRelayInterface {
   }
 
   // Address of the block pusher
-  address witnet;
+  address public witnet;
   // Last block reported
   Beacon public lastBlock;
 
@@ -62,6 +62,7 @@ contract MockBlockRelay is BlockRelayInterface {
   function getLastBeacon()
     external
     view
+    override
   returns(bytes memory)
   {
     return abi.encodePacked(lastBlock.blockHash, lastBlock.epoch);
@@ -69,13 +70,13 @@ contract MockBlockRelay is BlockRelayInterface {
 
   /// @notice Returns the lastest epoch reported to the block relay.
   /// @return epoch
-  function getLastEpoch() external view returns(uint256) {
+  function getLastEpoch() external view override returns(uint256) {
     return lastBlock.epoch;
   }
 
   /// @notice Returns the latest hash reported to the block relay
   /// @return blockhash
-  function getLastHash() external view returns(uint256) {
+  function getLastHash() external view override returns(uint256) {
     return lastBlock.blockHash;
   }
 
@@ -93,6 +94,7 @@ contract MockBlockRelay is BlockRelayInterface {
   external
   view
   blockExists(_blockHash)
+  override
   returns(bool)
   {
     uint256 drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
@@ -117,6 +119,7 @@ contract MockBlockRelay is BlockRelayInterface {
   external
   view
   blockExists(_blockHash)
+  override
   returns(bool)
   {
     uint256 tallyMerkleRoot = blocks[_blockHash].tallyHashMerkleRoot;
@@ -129,7 +132,7 @@ contract MockBlockRelay is BlockRelayInterface {
 
   /// @dev Determines if the contract is upgradable
   /// @return true
-  function isUpgradable(address _address) external view returns(bool) {
+  function isUpgradable(address) external view override returns(bool) {
     return true;
   }
 
@@ -143,7 +146,7 @@ contract MockBlockRelay is BlockRelayInterface {
     uint256 _epoch,
     uint256 _drMerkleRoot,
     uint256 _tallyMerkleRoot)
-    public
+    external
     isOwner
     blockDoesNotExist(_blockHash)
   {
@@ -159,24 +162,24 @@ contract MockBlockRelay is BlockRelayInterface {
   /// @param _blockHash Hash of the block header
   /// @return Requests-only merkle root hash in the block header.
   function readDrMerkleRoot(uint256 _blockHash)
-    public
+    external
     view
     blockExists(_blockHash)
-  returns(uint256 drMerkleRoot)
-    {
-    drMerkleRoot = blocks[_blockHash].drHashMerkleRoot;
+  returns(uint256)
+  {
+    return blocks[_blockHash].drHashMerkleRoot;
   }
 
   /// @dev Retrieve the tallies-only merkle root hash that was reported for a specific block header.
   /// @param _blockHash Hash of the block header
   /// tallies-only merkle root hash in the block header.
   function readTallyMerkleRoot(uint256 _blockHash)
-    public
+    external
     view
     blockExists(_blockHash)
-  returns(uint256 tallyMerkleRoot)
+  returns(uint256)
   {
-    tallyMerkleRoot = blocks[_blockHash].tallyHashMerkleRoot;
+    return blocks[_blockHash].tallyHashMerkleRoot;
   }
 
   /// @dev Verifies the validity of a PoI

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -41,7 +41,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     external
     payable
     override
-    returns(uint256)
+  returns(uint256)
   {
     uint256 _id = requests.length;
     DataRequest memory dr;

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -80,8 +80,8 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     return requests[_id].result;
   }
 
-  /// @dev Verifies if the contract is upgradable
-  /// @return true if the contract upgradable
+  /// @dev Verifies if the contract is upgradable.
+  /// @return true if the contract upgradable.
   function isUpgradable(address _address) external view override returns(bool) {
     if (_address == witnet) {
       return true;
@@ -89,9 +89,9 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     return false;
   }
 
-  /// @dev Retrieves hash of the data request transaction in Witnet
+  /// @dev Retrieves hash of the data request transaction in Witnet.
   /// @param _id The unique identifier of the data request.
-  /// @return The hash of the DataRequest transaction in Witnet
+  /// @return The hash of the DataRequest transaction in Witnet.
   function readDrHash (uint256 _id) external view override returns(uint256) {
     return requests[_id].drHash;
   }

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "../WitnetRequestsBoardInterface.sol";
 
@@ -22,9 +22,9 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     address payable pkhClaim;
   }
 
-  address witnet;
+  address public witnet;
 
-  DataRequest[] requests;
+  DataRequest[] public requests;
 
   constructor () public {
     // Insert an empty request so as to initialize the requests array with length > 0
@@ -40,6 +40,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
     external
     payable
+    override
     returns(uint256)
   {
     uint256 _id = requests.length;
@@ -58,6 +59,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
     external
     payable
+    override
   {
     requests[_id].inclusionReward += msg.value - _tallyReward;
     requests[_id].tallyReward += _tallyReward;
@@ -66,12 +68,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @dev Reports the result of a data request in Witnet.
   /// @param _id The unique identifier of the data request.
   /// @param _result The result itself as bytes.
-  function reportResult (
-    uint256 _id,
-    bytes calldata _result
-    )
-    external
- {
+  function reportResult (uint256 _id, bytes calldata _result) external {
     requests[_id].result = _result;
     msg.sender.transfer(requests[_id].tallyReward);
   }
@@ -79,16 +76,23 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR.
-  function readResult (uint256 _id) external view returns(bytes memory) {
+  function readResult (uint256 _id) external view override returns(bytes memory) {
     return requests[_id].result;
   }
 
   /// @dev Verifies if the contract is upgradable
   /// @return true if the contract upgradable
-  function isUpgradable(address _address) external view returns(bool) {
+  function isUpgradable(address _address) external view override returns(bool) {
     if (_address == witnet) {
       return true;
     }
     return false;
+  }
+
+  /// @dev Retrieves hash of the data request transaction in Witnet
+  /// @param _id The unique identifier of the data request.
+  /// @return The hash of the DataRequest transaction in Witnet
+  function readDrHash (uint256 _id) external view override returns(uint256) {
+    return requests[_id].drHash;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "witnet-ethereum-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Witnet-Ethereum Bridge Interface",
   "main": "",
   "scripts": {
@@ -32,8 +32,8 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "vrf-solidity": "girazoki/vrf-solidity#chore/versions",
-    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#chore/version"
+    "vrf-solidity": "0.2.2",
+    "witnet-ethereum-block-relay": "witnet/witnet-ethereum-block-relay"
   },
   "devDependencies": {
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "openzeppelin-solidity": "OpenZeppelin/openzeppelin-contracts#release-v3.0.0",
     "vrf-solidity": "girazoki/vrf-solidity#chore/versions",
     "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#chore/version"
   },

--- a/package.json
+++ b/package.json
@@ -32,29 +32,29 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "witnet-ethereum-block-relay": "witnet/witnet-ethereum-block-relay#master",
-    "openzeppelin-solidity": "2.4.0",
-    "vrf-solidity": "^0.2.1"
+    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#chore/version",
+    "openzeppelin-solidity": "OpenZeppelin/openzeppelin-contracts#release-v3.0.0",
+    "vrf-solidity": "girazoki/vrf-solidity#chore/versions"
   },
   "devDependencies": {
-    "dotenv": "^8.1.0",
-    "eslint": "^6.6.0",
+    "dotenv": "^8.2.0",
+    "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "ethlint": "^1.2.5",
-    "ganache-cli": "^6.7.0",
+    "ganache-cli": "^6.9.1",
     "js-sha256": "^0.9.0",
-    "solidity-coverage": "^0.6.7",
+    "solidity-coverage": "^0.7.2",
     "solium": "^1.2.5",
     "solium-plugin-security": "^0.1.1",
     "truffle-hdwallet-provider": "^1.0.13",
     "truffle-flattener": "git+https://github.com/witnet/truffle-flattener.git#single-experimental",
+    "truffle-plugin-verify": "^0.3.9",
     "truffle-verify": "^1.0.8",
-    "truffle-plugin-verify": "^0.3.8",
-    "truffle": "^5.1.0",
+    "truffle": "^5.1.17",
     "truffle-assertions": "^0.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "npm run compile-contracts",
     "compile-contracts": "truffle compile --all",
     "compile-flattened": "npx truffle compile --all --config flattened-config.js ",
-    "flatten": " mkdir contracts/flattened/ 2>/dev/null; npx truffle-flattener contracts/*.sol > contracts/flattened/Flattened.sol",   
+    "flatten": " mkdir contracts/flattened/ 2>/dev/null; npx truffle-flattener contracts/*.sol > contracts/flattened/Flattened.sol",
     "fmt": "solium -d contracts && eslint ./test && solium -d test",
     "fmt!": "solium -d contracts --fix && eslint ./test --fix && solium -d test --fix",
     "solium": "solium -d contracts",
@@ -32,9 +32,9 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#chore/version",
     "openzeppelin-solidity": "OpenZeppelin/openzeppelin-contracts#release-v3.0.0",
-    "vrf-solidity": "girazoki/vrf-solidity#chore/versions"
+    "vrf-solidity": "girazoki/vrf-solidity#chore/versions",
+    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#chore/version"
   },
   "devDependencies": {
     "dotenv": "^8.2.0",
@@ -50,11 +50,11 @@
     "solidity-coverage": "^0.7.2",
     "solium": "^1.2.5",
     "solium-plugin-security": "^0.1.1",
-    "truffle-hdwallet-provider": "^1.0.13",
-    "truffle-flattener": "git+https://github.com/witnet/truffle-flattener.git#single-experimental",
-    "truffle-plugin-verify": "^0.3.9",
-    "truffle-verify": "^1.0.8",
     "truffle": "^5.1.17",
-    "truffle-assertions": "^0.9.2"
+    "truffle-assertions": "^0.9.2",
+    "truffle-flattener": "git+https://github.com/witnet/truffle-flattener.git#single-experimental",
+    "truffle-hdwallet-provider": "^1.0.13",
+    "truffle-plugin-verify": "^0.3.9",
+    "truffle-verify": "^1.0.8"
   }
 }

--- a/test/TestActiveBridgeSet.sol
+++ b/test/TestActiveBridgeSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "truffle/Assert.sol";
 import "../contracts/ActiveBridgeSetLib.sol";
@@ -8,29 +8,29 @@ contract TestActiveBridgeSet {
 
   using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
 
-  uint8 constant CLAIM_BLOCK_PERIOD = 8;
-  uint16 constant ACTIVITY_LENGTH = 100;
+  uint8 constant private CLAIM_BLOCK_PERIOD = 8;
+  uint16 constant private ACTIVITY_LENGTH = 100;
 
-  address[] addresses = [
+  address[] private addresses = [
     address(0x01),
     address(0x02),
     address(0x03),
     address(0x04)
   ];
 
-  ActiveBridgeSetLib.ActiveBridgeSet abs;
+  ActiveBridgeSetLib.ActiveBridgeSet private abs;
 
-  function beforeEach() public {
+  function beforeEach() external {
     abs.lastBlockNumber = 0;
     abs.updateActivity(CLAIM_BLOCK_PERIOD * ACTIVITY_LENGTH);
     abs.lastBlockNumber = 0;
   }
 
-  function testGetABSEmpty() public {
+  function testGetABSEmpty() external {
     verifyABSStatus(0, 0, 0);
   }
 
-  function testPushActivityNextEpoch() public {
+  function testPushActivityNextEpoch() external {
     abs.pushActivity(msg.sender, 0);
     verifyABSStatus(0, 1, 0);
 
@@ -38,7 +38,7 @@ contract TestActiveBridgeSet {
     verifyABSStatus(1, 1, CLAIM_BLOCK_PERIOD);
   }
 
-  function testPushActivityTwice() public {
+  function testPushActivityTwice() external {
     abs.pushActivity(msg.sender, 0);
     verifyABSStatus(0, 1, 0);
     verifyIdentityCount(msg.sender, 1);
@@ -56,7 +56,7 @@ contract TestActiveBridgeSet {
     verifyIdentityCount(msg.sender, 3);
   }
 
-  function testPushActivityOverflow() public {
+  function testPushActivityOverflow() external {
     abs.pushActivity(msg.sender, 0);
     verifyABSStatus(0, 1, 0);
     verifyIdentityCount(msg.sender, 1);
@@ -70,7 +70,7 @@ contract TestActiveBridgeSet {
     verifyIdentityCount(msg.sender, 1);
   }
 
-  function testPushActivityMultipleIdentities() public {
+  function testPushActivityMultipleIdentities() external {
     abs.pushActivity(addresses[0], 0);
     abs.pushActivity(addresses[1], 0);
     verifyABSStatus(0, 2, 0);
@@ -104,7 +104,7 @@ contract TestActiveBridgeSet {
     verifyIdentityCount(addresses[3], 2);
   }
 
-  function testUpdateActivity() public {
+  function testUpdateActivity() external {
     abs.pushActivity(addresses[0], 0);
     verifyABSStatus(0, 1, 0);
 

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "truffle/Assert.sol";
 import "../contracts/BufferLib.sol";
@@ -10,7 +10,7 @@ contract TestBuffer {
 
   event Log(string _topic, uint256 _value);
 
-  function testReadUint8() public {
+  function testReadUint8() external {
     uint8 expected = 31;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -19,7 +19,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint8 from a Buffer");
   }
 
-  function testReadUint16() public {
+  function testReadUint16() external {
     uint16 expected = 31415;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -28,7 +28,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint16 from a Buffer");
   }
 
-  function testReadUint32() public {
+  function testReadUint32() external {
     uint32 expected = 3141592653;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -37,7 +37,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint32 from a Buffer");
   }
 
-  function testReadUint64() public {
+  function testReadUint64() external {
     uint64 expected = 3141592653589793238;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -46,7 +46,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint64 from a Buffer");
   }
 
-  function testReadUint128() public {
+  function testReadUint128() external {
     uint128 expected = 314159265358979323846264338327950288419;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -55,7 +55,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint128 from a Buffer");
   }
 
-  function testReadUint256() public {
+  function testReadUint256() external {
     uint256 expected = 31415926535897932384626433832795028841971693993751058209749445923078164062862;
     bytes memory data = abi.encodePacked(expected);
     BufferLib.Buffer memory buf = BufferLib.Buffer(data, 0);
@@ -64,7 +64,7 @@ contract TestBuffer {
     Assert.equal(uint(actual), uint(expected), "Read Uint64 from a Buffer");
   }
 
-  function testMultipleReadHead() public {
+  function testMultipleReadHead() external {
     uint8 small = 31;
     uint64 big = 3141592653589793238;
     bytes memory data = abi.encodePacked(small, big);

--- a/test/TestCBOR.sol
+++ b/test/TestCBOR.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 pragma experimental ABIEncoderV2;
 
 import "truffle/Assert.sol";
@@ -11,12 +11,12 @@ contract TestCBOR {
   event Log(string _topic, uint256 _value);
   event Log(string _topic, bytes _value);
 
-  function testUint64DecodeDiscriminant() public {
+  function testUint64DecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"1b0020000000000000");
     Assert.equal(uint(decoded.majorType), 0, "CBOR-encoded Uint64 value should be decoded into a CBOR.Value with major type 0");
   }
 
-  function testUint64DecodeValue() public {
+  function testUint64DecodeValue() external {
     uint64 decoded = CBOR.valueFromBytes(hex"1b0020000000000000").decodeUint64();
     Assert.equal(
       uint(decoded),
@@ -25,12 +25,12 @@ contract TestCBOR {
     );
   }
 
-  function testInt128DecodeDiscriminant() public {
+  function testInt128DecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"3bfffffffffffffffe");
     Assert.equal(uint(decoded.majorType), 1, "CBOR-encoded Int128 value should be decoded into a CBOR.Value with major type 1");
   }
 
-  function testInt128DecodeValue() public {
+  function testInt128DecodeValue() external {
     int128 decoded = CBOR.valueFromBytes(hex"3bfffffffffffffffe").decodeInt128();
     Assert.equal(
       int(decoded),
@@ -39,28 +39,28 @@ contract TestCBOR {
     );
   }
 
-  function testInt128DecodeZeroValue() public {
+  function testInt128DecodeZeroValue() external {
     int128 decoded = CBOR.valueFromBytes(hex"00").decodeInt128();
     Assert.equal(int(decoded), 0, "CBOR-encoded Int128 value should be decoded into a CBOR.Value containing the correct Uint64 value");
   }
 
-  function testBytes0DecodeDiscriminant() public {
+  function testBytes0DecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"40");
     Assert.equal(uint(decoded.majorType), 2, "Empty CBOR-encoded Bytes value should be decoded into a CBOR.Value with major type 2");
   }
 
-  function testBytes0DecodeValue() public {
+  function testBytes0DecodeValue() external {
     bytes memory encoded = hex"40";
     bytes memory decoded = CBOR.valueFromBytes(encoded).decodeBytes();
     Assert.equal(decoded.length, 0, "Empty CBOR-encoded Bytes value should be decoded into an empty CBOR.Value containing an empty bytes value");
   }
 
-  function testBytes4BDecodeDiscriminant() public {
+  function testBytes4BDecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"4401020304");
     Assert.equal(uint(decoded.majorType), 2, "CBOR-encoded Bytes value should be decoded into a CBOR.Value with major type 2");
   }
 
-  function testBytes4DecodeValue() public {
+  function testBytes4DecodeValue() external {
     bytes memory encoded = hex"4401020304";
     bytes memory decoded = CBOR.valueFromBytes(encoded).decodeBytes();
     bytes memory expected = abi.encodePacked(
@@ -92,12 +92,12 @@ contract TestCBOR {
     );
   }
 
-  function testStringDecodeDiscriminant() public {
+  function testStringDecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"6449455446");
     Assert.equal(uint(decoded.majorType), 3, "CBOR-encoded String value should be decoded into a CBOR.Value with major type 3");
   }
 
-  function testStringDecodeValue() public {
+  function testStringDecodeValue() external {
     bytes memory encoded = hex"6449455446";
     string memory decoded = CBOR.valueFromBytes(encoded).decodeString();
     string memory expected = "IETF";
@@ -105,12 +105,12 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded String value should be decoded into a CBOR.Value containing the correct String value");
   }
 
-  function testFloatDecodeDiscriminant() public {
+  function testFloatDecodeDiscriminant() external {
     CBOR.Value memory decoded = CBOR.valueFromBytes(hex"f90001");
     Assert.equal(uint(decoded.majorType), 7, "CBOR-encoded Float value should be decoded into a CBOR with major type 7");
   }
 
-  function testFloatDecodeSmallestSubnormal() public {
+  function testFloatDecodeSmallestSubnormal() external {
     bytes memory encoded = hex"f90001";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 0;
@@ -118,7 +118,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeLargestSubnormal() public {
+  function testFloatDecodeLargestSubnormal() external {
     bytes memory encoded = hex"f903ff";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 0;
@@ -126,7 +126,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeSmallestPositiveNormal() public {
+  function testFloatDecodeSmallestPositiveNormal() external {
     bytes memory encoded = hex"f90400";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 0;
@@ -134,7 +134,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeLargestNormal() public {
+  function testFloatDecodeLargestNormal() external {
     bytes memory encoded = hex"f97bff";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 655040000;
@@ -142,7 +142,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeLargestLessThanOne() public {
+  function testFloatDecodeLargestLessThanOne() external {
     bytes memory encoded = hex"f93bff";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 9995;
@@ -150,7 +150,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeOne() public {
+  function testFloatDecodeOne() external {
     bytes memory encoded = hex"f93c00";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 10000;
@@ -158,7 +158,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeSmallestGreaterThanOne() public {
+  function testFloatDecodeSmallestGreaterThanOne() external {
     bytes memory encoded = hex"f93c01";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 10009;
@@ -166,7 +166,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeOneThird() public {
+  function testFloatDecodeOneThird() external {
     bytes memory encoded = hex"f93555";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 3332;
@@ -174,7 +174,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeMinusTwo() public {
+  function testFloatDecodeMinusTwo() external {
     bytes memory encoded = hex"f9c000";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = -20000;
@@ -182,7 +182,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeZero() public {
+  function testFloatDecodeZero() external {
     bytes memory encoded = hex"f90000";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 0;
@@ -190,7 +190,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testFloatDecodeMinusZero() public {
+  function testFloatDecodeMinusZero() external {
     bytes memory encoded = hex"f98000";
     int32 decoded = CBOR.valueFromBytes(encoded).decodeFixed16();
     int32 expected = 0;
@@ -198,7 +198,7 @@ contract TestCBOR {
     Assert.equal(decoded, expected, "CBOR-encoded Float value should be decoded into a CBOR.Value containing the correct Float value");
   }
 
-  function testUint64ArrayDecode() public {
+  function testUint64ArrayDecode() external {
     bytes memory encoded = hex"840102031a002fefd8";
     uint64[] memory decoded = CBOR.valueFromBytes(encoded).decodeUint64Array();
     uint64[4] memory expected = [
@@ -230,7 +230,7 @@ contract TestCBOR {
     );
   }
 
-  function testInt128ArrayDecode() public {
+  function testInt128ArrayDecode() external {
     bytes memory encoded = hex"840121033a002fefd7";
     int128[] memory decoded = CBOR.valueFromBytes(encoded).decodeInt128Array();
     int128[4] memory expected = [
@@ -262,7 +262,7 @@ contract TestCBOR {
     );
   }
 
-  function testFixed16ArrayDecode() public {
+  function testFixed16ArrayDecode() external {
     bytes memory encoded = hex"84f93c80f9c080f94290f9C249";
     int128[] memory decoded = CBOR.valueFromBytes(encoded).decodeFixed16Array();
     int128[4] memory expected = [
@@ -293,7 +293,7 @@ contract TestCBOR {
     );
   }
 
-  function testStringArrayDecode() public {
+  function testStringArrayDecode() external {
     bytes memory encoded = hex"846548656c6c6f6d646563656e7472616c697a656465776f726c646121";
     string[] memory decoded = CBOR.valueFromBytes(encoded).decodeStringArray();
     string[4] memory expected = [

--- a/test/Witnet.sol
+++ b/test/Witnet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 pragma experimental ABIEncoderV2;
 
 import "truffle/Assert.sol";
@@ -10,19 +10,19 @@ contract WitnetTest {
 
   // Test the `Witnet.stageNames` pure method, which gives strings with the names for the different Witnet request
   // stages
-  function testStageNames() public {
+  function testStageNames() external {
     Assert.equal(Witnet.stageName(0), "retrieval", "Stage name for stage #1 should be \"retrieval\"");
     Assert.equal(Witnet.stageName(1), "aggregation", "Stage name for stage #1 should be \"aggregation\"");
     Assert.equal(Witnet.stageName(2), "tally", "Stage name for stage #1 should be \"tally\"");
   }
 
   // Check that all the RADON errors are supported
-  function testErrorCodesSize() public {
+  function testErrorCodesSize() external {
     Assert.equal(uint(Witnet.ErrorCodes.Size), uint(67), "Not every RADON error is supported in `Witnet.ErrorCodes`");
   }
 
   // Test decoding of `RadonError` error codes
-  function testErrorCodes() public {
+  function testErrorCodes() external {
     Witnet.ErrorCodes errorCode0x00 = Witnet.resultFromCborBytes(hex"D8278100").asErrorCode();
     Witnet.ErrorCodes errorCode0x01 = Witnet.resultFromCborBytes(hex"D8278101").asErrorCode();
     Witnet.ErrorCodes errorCode0x02 = Witnet.resultFromCborBytes(hex"D8278102").asErrorCode();
@@ -98,7 +98,7 @@ contract WitnetTest {
   }
 
   // Test decoding of `RadonError` error messages
-  function testErrorMessages() public {
+  function testErrorMessages() external {
     (, string memory errorMessage0x00) = Witnet.resultFromCborBytes(hex"D8278100").asErrorMessage();
     (, string memory errorMessage0x01) = Witnet.resultFromCborBytes(hex"D827820102").asErrorMessage();
     (, string memory errorMessage0x02) = Witnet.resultFromCborBytes(hex"D827820203").asErrorMessage();

--- a/test/helpers/UsingWitnetBytesTestHelper.sol
+++ b/test/helpers/UsingWitnetBytesTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "../../contracts/UsingWitnetBytes.sol";
 
@@ -13,15 +13,15 @@ contract UsingWitnetBytesTestHelper is UsingWitnetBytes {
 
   constructor (address _wrbAddress) UsingWitnetBytes(_wrbAddress) public {}
 
-  function _witnetPostDataRequest(bytes memory _dr, uint256 _tallyReward) public payable returns(uint256 id) {
+  function _witnetPostDataRequest(bytes calldata _dr, uint256 _tallyReward) external payable returns(uint256 id) {
     return witnetPostRequest(_dr, _tallyReward);
   }
 
-  function _witnetUpgradeDataRequest(uint256 _id, uint256 _tallyReward) public payable {
+  function _witnetUpgradeDataRequest(uint256 _id, uint256 _tallyReward) external payable {
     witnetUpgradeRequest(_id, _tallyReward);
   }
 
-  function _witnetReadResult (uint256 _id) public returns(bytes memory) {
+  function _witnetReadResult (uint256 _id) external view returns(bytes memory) {
     return witnetReadResult(_id);
   }
 }

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 pragma experimental ABIEncoderV2;
 
 import "../../contracts/Request.sol";
@@ -19,20 +19,20 @@ contract UsingWitnetTestHelper is UsingWitnet {
 
   constructor (address _wrbAddress) UsingWitnet(_wrbAddress) public { }
 
-  function _witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward) public payable returns(uint256 id) {
-    return witnetPostRequest(_request, _requestReward, _resultReward);
+  function _witnetPostRequest(Request _request, uint256 _tallyReward) external payable returns(uint256 id) {
+    return witnetPostRequest(_request, _tallyReward);
   }
 
-  function _witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) public payable {
+  function _witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) external payable {
     witnetUpgradeRequest(_id, _tallyReward);
   }
 
-  function _witnetReadResult(uint256 _requestId) public returns(Witnet.Result memory) {
+  function _witnetReadResult(uint256 _requestId) external returns(Witnet.Result memory) {
     result = witnetReadResult(_requestId);
     return result;
   }
 
-  function _witnetAsUint64() public view returns(uint64) {
+  function _witnetAsUint64() external view returns(uint64) {
     return result.asUint64();
   }
 

--- a/test/helpers/WitnetRequestsBoardTestHelper.sol
+++ b/test/helpers/WitnetRequestsBoardTestHelper.sol
@@ -35,7 +35,9 @@ contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
     uint256[2] calldata _publicKey,
     uint256[2] calldata _uPoint,
     uint256[4] calldata _vPointHelpers)
-  external view returns(bool)
+    external
+    view
+  returns(bool)
   {
     return verifyPoe(
       _poe,
@@ -47,9 +49,9 @@ contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
   function _verifySig(
     bytes calldata _message,
     uint256[2] calldata _publicKey,
-    bytes calldata _addrSignature
-  )
-  external returns(bool)
+    bytes calldata _addrSignature)
+    external
+  returns(bool)
   {
     return verifySig(
       _message,

--- a/test/helpers/WitnetRequestsBoardTestHelper.sol
+++ b/test/helpers/WitnetRequestsBoardTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "../../contracts/WitnetRequestsBoard.sol";
 
@@ -12,23 +12,18 @@ import "../../contracts/WitnetRequestsBoard.sol";
 
 
 contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
-  WitnetRequestsBoard wrb;
-  //uint256 blockHash;
-  // epoch of the last block
-  //uint256 epoch;
-  uint256 blockHash;
-  uint256 epoch;
 
-  constructor (
-    address _blockRelayAddress,
-    uint8 _repFactor)
-  WitnetRequestsBoard(_blockRelayAddress, _repFactor) public { }
+  WitnetRequestsBoard private wrb;
+  uint256 private blockHash;
+  uint256 private epoch;
 
-  modifier vrfValid(
+  constructor(address _blockRelayAddress, uint8 _repFactor) WitnetRequestsBoard(_blockRelayAddress, _repFactor) public { }
+
+  modifier vrfValid (
     uint256[4] memory _poe,
     uint256[2] memory _publicKey,
     uint256[2] memory _uPoint,
-    uint256[4] memory _vPointHelpers) {
+    uint256[4] memory _vPointHelpers) override {
     require(
       true,
       "Not a valid VRF");
@@ -36,11 +31,11 @@ contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
   }
 
   function _verifyPoe(
-    uint256[4] memory _poe,
-    uint256[2] memory _publicKey,
-    uint256[2] memory _uPoint,
-    uint256[4] memory _vPointHelpers)
-  public view returns(bool)
+    uint256[4] calldata _poe,
+    uint256[2] calldata _publicKey,
+    uint256[2] calldata _uPoint,
+    uint256[4] calldata _vPointHelpers)
+  external view returns(bool)
   {
     return verifyPoe(
       _poe,
@@ -50,11 +45,11 @@ contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
   }
 
   function _verifySig(
-    bytes memory _message,
-    uint256[2] memory _publicKey,
-    bytes memory _addrSignature
+    bytes calldata _message,
+    uint256[2] calldata _publicKey,
+    bytes calldata _addrSignature
   )
-  public returns(bool)
+  external returns(bool)
   {
     return verifySig(
       _message,
@@ -62,18 +57,14 @@ contract WitnetRequestsBoardTestHelper is WitnetRequestsBoard {
       _addrSignature);
   }
 
-  function getLastBeacon()
-    public
-    view
-  returns(bytes memory)
-  {
-    return abi.encodePacked(blockHash, epoch);
-  }
-
   function setActiveIdentities(uint32 _abs)
-    public
+    external
   {
     abs.activeIdentities = _abs;
+  }
+
+  function getLastBeacon() public view override returns(bytes memory) {
+    return abi.encodePacked(blockHash, epoch);
   }
 
 }

--- a/test/helpers/WrbProxyTestHelper.sol
+++ b/test/helpers/WrbProxyTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
 import "../../contracts/WitnetRequestsBoardProxy.sol";
 

--- a/test/test_instances/WitnetRequestsBoardV1.sol
+++ b/test/test_instances/WitnetRequestsBoardV1.sol
@@ -62,12 +62,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
-    external
-    payable
-    override
-    returns(uint256)
-  {
+  function postDataRequest(bytes calldata _dr, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);

--- a/test/test_instances/WitnetRequestsBoardV1.sol
+++ b/test/test_instances/WitnetRequestsBoardV1.sol
@@ -1,6 +1,5 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "../../contracts/ActiveBridgeSetLib.sol";
 import "witnet-ethereum-block-relay/contracts/BlockRelayProxy.sol";
@@ -17,7 +16,6 @@ import "../../contracts/WitnetRequestsBoardInterface.sol";
  */
 contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
 
-  using SafeMath for uint256;
   using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
 
   struct DataRequest {
@@ -67,6 +65,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
     external
     payable
+    override
     returns(uint256)
   {
     uint256 _id = requests.length;
@@ -90,6 +89,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
     external
     payable
+    override
   {
     requests[_id].inclusionReward += msg.value - _tallyReward;
     requests[_id].tallyReward += _tallyReward;
@@ -98,20 +98,20 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   /// @dev Retrieves hash of the data request transaction in Witnet
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DataRequest transaction in Witnet
-  function readDrHash (uint256 _id) external view returns(uint256) {
+  function readDrHash (uint256 _id) external view override returns(uint256) {
     return requests[_id].drHash;
   }
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
-  function readResult (uint256 _id) external view returns(bytes memory) {
+  function readResult (uint256 _id) external view override returns(bytes memory) {
     return requests[_id].result;
   }
 
    /// @dev Verifies if the contract is upgradable
   /// @return true if the contract upgradable
-  function isUpgradable(address _address) external view returns(bool) {
+  function isUpgradable(address _address) external view override returns(bool) {
     return true;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV2.sol
+++ b/test/test_instances/WitnetRequestsBoardV2.sol
@@ -1,6 +1,5 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "../../contracts/ActiveBridgeSetLib.sol";
 import "witnet-ethereum-block-relay/contracts/BlockRelayProxy.sol";
@@ -17,7 +16,6 @@ import "../../contracts/WitnetRequestsBoardInterface.sol";
  */
 contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
 
-  using SafeMath for uint256;
   using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
 
   struct DataRequest {
@@ -67,6 +65,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
     external
     payable
+    override
     returns(uint256)
   {
     uint256 _id = requests.length;
@@ -90,6 +89,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
     external
     payable
+    override
   {
     requests[_id].inclusionReward += msg.value - _tallyReward;
     requests[_id].tallyReward += _tallyReward;
@@ -98,20 +98,20 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   /// @dev Retrieves hash of the data request transaction in Witnet
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DataRequest transaction in Witnet
-  function readDrHash (uint256 _id) external view returns(uint256) {
+  function readDrHash (uint256 _id) external view override returns(uint256) {
     return requests[_id].drHash;
   }
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
-  function readResult (uint256 _id) external view returns(bytes memory) {
+  function readResult (uint256 _id) external view override returns(bytes memory) {
     return requests[_id].result;
   }
 
    /// @dev Verifies if the contract is upgradable
   /// @return true if the contract upgradable
-  function isUpgradable(address _address) external view returns(bool) {
+  function isUpgradable(address _address) external view override returns(bool) {
     return true;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV2.sol
+++ b/test/test_instances/WitnetRequestsBoardV2.sol
@@ -62,12 +62,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
-    external
-    payable
-    override
-    returns(uint256)
-  {
+  function postDataRequest(bytes calldata _dr, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);

--- a/test/test_instances/WitnetRequestsBoardV3.sol
+++ b/test/test_instances/WitnetRequestsBoardV3.sol
@@ -1,6 +1,5 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.6.4;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "vrf-solidity/contracts/VRF.sol";
 import "../../contracts/ActiveBridgeSetLib.sol";
 import "witnet-ethereum-block-relay/contracts/BlockRelayProxy.sol";
@@ -17,7 +16,6 @@ import "../../contracts/WitnetRequestsBoardInterface.sol";
  */
 contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
 
-  using SafeMath for uint256;
   using ActiveBridgeSetLib for ActiveBridgeSetLib.ActiveBridgeSet;
 
   struct DataRequest {
@@ -67,6 +65,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
     external
     payable
+    override
     returns(uint256)
   {
     uint256 _id = requests.length;
@@ -90,6 +89,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
     external
     payable
+    override
   {
     requests[_id].inclusionReward += msg.value - _tallyReward;
     requests[_id].tallyReward += _tallyReward;
@@ -98,20 +98,20 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   /// @dev Retrieves hash of the data request transaction in Witnet
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DataRequest transaction in Witnet
-  function readDrHash (uint256 _id) external view returns(uint256) {
+  function readDrHash (uint256 _id) external view override returns(uint256) {
     return requests[_id].drHash;
   }
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
-  function readResult (uint256 _id) external view returns(bytes memory) {
+  function readResult (uint256 _id) external view override returns(bytes memory) {
     return requests[_id].result;
   }
 
    /// @dev Verifies if the contract is upgradable
   /// @return true if the contract upgradable
-  function isUpgradable(address _address) external view returns(bool) {
+  function isUpgradable(address _address) external view override returns(bool) {
     return false;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV3.sol
+++ b/test/test_instances/WitnetRequestsBoardV3.sol
@@ -62,12 +62,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   /// @param _dr The bytes corresponding to the Protocol Buffers serialization of the data request output.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(bytes calldata _dr, uint256 _tallyReward)
-    external
-    payable
-    override
-    returns(uint256)
-  {
+  function postDataRequest(bytes calldata _dr, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -53,7 +53,7 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should post a Witnet request into the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+      requestId = await returnData(clientContract._witnetPostRequest(request.address, resultReward, {
         from: accounts[0],
         value: requestReward + resultReward,
       }))
@@ -254,7 +254,7 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should pass the data request to the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+      requestId = await returnData(clientContract._witnetPostRequest(request.address, resultReward, {
         from: accounts[0],
         value: requestReward + resultReward,
       }))

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -39,7 +39,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.6.4",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {


### PR DESCRIPTION
Fix errors from code review #68 : 

```
·----------------------------------------------·--------------·-------·
|                Error Type                    |  Occurences  | FIXED |
······································································|
| Unsafe array's length manipulation           |           2  |     0 |
······································································|
| Multiplication after division                |           1  |     0 |
······································································|
| Extra gas consumption                        |           3  |     3 |
······································································|
| Costly loop                                  |           6  |     0 |
······································································|
| Locked money                                 |           5  |     0 |
······································································|
| Compiler version not fixed                   |          25  |    16 |
······································································|
| Revert inside the if-operator                |           3  |     3 |
·······································································
| Use of SafeMath                              |           4  |     4 |
······································································|
| Pure-functions should not read/change state  |           7  |     0 |
······································································|
| Non-strict comparison with zero              |           3  |     3 |
······································································|
| Prefer external to public visibility level   |          86  |    86 |
······································································|
| Use of assembly                              |           7  |     0 |
······································································|
| Implicit visibility level                    |          32  |    32 |
·----------------------------------------------·--------------·-------·
| TOTAL                                        |         184  |    99 |
·----------------------------------------------·--------------·-------·
```

### Unsafe array's length manipulation: NOT FIXED

These are most probably false negatives caused by mutation of the `length` attribute of a `CBOR.Value memory` data structure, which is wrongly identified by Smartcheck as a length mutation of a dynamic array. This assumption can be validated by renaming `length` as `len` and checking if the same error shows up.

### Multiplication after division: NOT FIXED

Potential precision errors due to a division prior to multiplication. In this case, division is done before in order to avoid overflows. This equation re-arrange was the one leading to less precision/overflow errors.

### Extra gas consumption: FIXED

Potential extra gas consumption due to state variable (e.g. `.length`) of non-memory array is used in the condition of for or while loop.

### Costly loop: NOT FIXED

Comments for errors 1-2:
 - the array length refers to DRs to be claimed
 - the transaction creator is the one interested in using an array of IDs not-long enough to be under the block gas limit

All potentially constly loops in `CBOR.sol` (Errors 4-6) are inherited from the specification in RFC 7049 and are therefore unavoidable. Because of the way in which CBOR is designed to operate, the number of iterations is determined by the value of the first bytes in the `_cborValue.buffer` input.
This could theoretically cause the loop to iterate enough times for the transaction to hit the gas limit. May a third-party contract's business logic depend on this piece of could, it could become unreachable forever. However, there are only two circumstances in which we may find a `_cborValue.buffer` which specified a significantly high length:
1. Ill-intended nonconforming CBOR values that may be specially crafted to force this situation by specifying a declared length that exceeds the actual length of the input bytes. In this case, the algorithm will most surely panic because of shortage of bytes before hitting any gas limit.
2. CBOR values that are actually huge in size. Generally speaking, these loops are indeed not guarded against that possibility. However, specifically in our case, gas limits would be most surely reached by the preceding transaction supplying the input bytes and storing them into `WitnetRequestsBoard`.

### Locked money: NOT FIXED

The SmartDec tool complains about a smart contract having payable methods but without .send, .value, or .transfer methods inside it. In our case, it complains about the Test Helper smart contracts, but these inherit the UsingWitnet.sol contract which has `.value` methods.

### Compiler version not fixed

All have been fixed. Libraries have been instructed to allow any versions from 0.5.3 to less than 0.7.

### Revert inside the if-operator: FIXED

Reverts inside if clauses are not recommended, instead require should be used.

### Use of SafeMath: WILL FIX

According to SmartDec tool, it is a good practice to add overflow checks (SafeMath) only in cases overflow may occur.

### Pure-functions should not read/change state: NOT FIXED

These errors arise when pure functions are potentially changing the state of the contract. Since the tool does not understand assembly language, it does not have a method to derive whether the code is modifying the state. In our cases none of our assembly code is modifying the state of the contracts, but rather input arguments or local variables.

### Non-strict comparison with zero: FIXED

These errors arise when doing some useless comparison, like checking whether an `uint` is bigger or equal than 0.

### Prefer external to public visibility level: FIXED

All functions which have as arguments native solidity types have been renamed external.

### Use of assembly: NOT FIXED

The tool, whenever assembly code is detected, triggers an alarm. These will not be fixed as the assembly code is necessary for the `Buffer` library and a signature verification.

### Implicit visibility level: FIXED

This implies some of the state variables do not have visibility assigned, which by default assigns the public visibility.

