### PR TITLE
Prevent loss of funds when using the UsingWitnet contract

### DIFF
--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -34,12 +34,11 @@ contract UsingWitnet {
   * @notice Send a new request to the Witnet network
   * @dev Call to `post_dr` function in the WitnetRequestsBoard contract
   * @param _request An instance of the `Request` contract
-  * @param _requestReward Reward specified for the user which posts the request into Witnet
-  * @param _resultReward Reward specified for the user which posts back the request result
+  * @param _tallyReward Reward specified for the user which post the Data Request result.
   * @return Sequencial identifier for the request included in the WitnetRequestsBoard
   */
-  function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward) internal returns (uint256) {
-    return wrb.postDataRequest.value(_requestReward + _resultReward)(_request.bytecode(), _resultReward);
+  function witnetPostRequest(Request _request, uint256 _tallyReward) internal returns (uint256) {
+    return wrb.postDataRequest.value(msg.value)(_request.bytecode(), _tallyReward);
   }
 
   /**

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -19,8 +19,8 @@ contract UsingWitnetTestHelper is UsingWitnet {
 
   constructor (address _wrbAddress) UsingWitnet(_wrbAddress) public { }
 
-  function _witnetPostRequest(Request _request, uint256 _requestReward, uint256 _tallyReward) external payable returns(uint256 id) {
-    return witnetPostRequest(_request, _requestReward, _tallyReward);
+  function _witnetPostRequest(Request _request, uint256 _tallyReward) external payable returns(uint256 id) {
+    return witnetPostRequest(_request, _tallyReward);
   }
 
   function _witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) external payable {

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -20,7 +20,7 @@ contract("UsingWitnet", accounts => {
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
     const requestReward = 7000000000000000
-    const resultReward = 3000000000000000
+    const tallyReward = 3000000000000000
 
     let witnet, clientContract, wrb, wrbProxy, blockRelay, request, requestId, requestHash, result, blockRelayProxy
     let lastAccount0Balance, lastAccount1Balance
@@ -53,9 +53,9 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should post a Witnet request into the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+      requestId = await returnData(clientContract._witnetPostRequest(request.address, tallyReward, {
         from: accounts[0],
-        value: requestReward + resultReward,
+        value: requestReward + tallyReward,
       }))
       const expectedId = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
@@ -73,7 +73,7 @@ contract("UsingWitnet", accounts => {
       const actualInclusionReward = drInfo.inclusionReward.toString()
       const actualTallyReward = drInfo.tallyReward.toString()
       assert.equal(actualInclusionReward, requestReward)
-      assert.equal(actualTallyReward, resultReward)
+      assert.equal(actualTallyReward, tallyReward)
     })
 
     it("requester balance should decrease", async () => {
@@ -89,13 +89,13 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, requestReward + resultReward)
+      assert.equal(wrbBalance, requestReward + tallyReward)
     })
 
     it("should upgrade the rewards of a existing Witnet request", async () => {
-      await returnData(clientContract._witnetUpgradeRequest(requestId, resultReward, {
+      await returnData(clientContract._witnetUpgradeRequest(requestId, tallyReward, {
         from: accounts[0],
-        value: requestReward + resultReward,
+        value: requestReward + tallyReward,
       }))
     })
 
@@ -105,12 +105,12 @@ contract("UsingWitnet", accounts => {
       const actualInclusionReward = drInfo.inclusionReward.toString()
       const actualTallyReward = drInfo.tallyReward.toString()
       assert.equal(actualInclusionReward, requestReward * 2)
-      assert.equal(actualTallyReward, resultReward * 2)
+      assert.equal(actualTallyReward, tallyReward * 2)
     })
 
     it("requester balance should decrease after rewards upgrade", async () => {
       const afterBalance = await web3.eth.getBalance(accounts[0])
-      assert(afterBalance < lastAccount0Balance - requestReward - resultReward)
+      assert(afterBalance < lastAccount0Balance - requestReward - tallyReward)
       lastAccount0Balance = afterBalance
     })
 
@@ -121,7 +121,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase after rewards upgrade", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, (requestReward + resultReward) * 2)
+      assert.equal(wrbBalance, (requestReward + tallyReward) * 2)
     })
 
     it("should claim eligibility for relaying the request into Witnet", async () => {
@@ -225,7 +225,7 @@ contract("UsingWitnet", accounts => {
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
     const requestReward = 7000000000000000
-    const resultReward = 3000000000000000
+    const tallyReward = 3000000000000000
 
     let witnet, clientContract, wrb, blockRelay, blockRelayProxy, request, requestId, requestHash, result
 
@@ -254,9 +254,9 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should pass the data request to the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+      requestId = await returnData(clientContract._witnetPostRequest(request.address, tallyReward, {
         from: accounts[0],
-        value: requestReward + resultReward,
+        value: requestReward + tallyReward,
       }))
       assert.equal(requestId.toString(16), "0x0000000000000000000000000000000000000000000000000000000000000001")
     })


### PR DESCRIPTION
It has been verified that there is a different behaviour between `UsingWitnet` and `UsingWitnetBytes`. The first one, does not send the total of ether that has been sent during the transaction, instead it sends the sum of the two parameters of the fee. This behaviour can lead to the burning of funds if the contract that implements it, does not include a withdrawal mechanism.

It is recommended to unify the criteria of both contracts, so the `UsingWitnetBytes` mechanism, should be the standard one.

PS: This change requires modifying the examples `witnet/truffle-box` and `stampery-labs/witnet-pricefeed-example`.