### PR TITLE
fix: preventing burning user funds

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,2 +1,3 @@
 node_modules
 contracts/Migrations.sol
+contracts/flattened/Flattened.sol

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -30,10 +30,10 @@ contract UsingWitnet {
     _;
   }
 
-  // // Ensures that user-specified rewards are equal to the total transaction value to prevent users from burning any excess value
-  modifier rewardsValid(uint256 _requestReward, uint256 _resultReward) {
+  // Ensures that user-specified rewards are equal to the total transaction value to prevent users from burning any excess value
+  modifier validRewards(uint256 _requestReward, uint256 _resultReward) {
     require(_requestReward + _resultReward >= _requestReward, "The sum of rewards overflows");
-    require(msg.value == _requestReward + _resultReward, "The sum of rewards should be equal to transaction value");
+    require(msg.value == _requestReward + _resultReward, "Transaction value should equal the sum of rewards");
     _;
   }
 
@@ -47,7 +47,7 @@ contract UsingWitnet {
   */
   function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward)
     internal
-    rewardsValid(_requestReward, _resultReward)
+    validRewards(_requestReward, _resultReward)
   returns (uint256)
   {
     return wrb.postDataRequest.value(_requestReward + _resultReward)(_request.bytecode(), _resultReward);
@@ -77,7 +77,7 @@ contract UsingWitnet {
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _resultReward)
     internal
-    rewardsValid(_requestReward, _resultReward)
+    validRewards(_requestReward, _resultReward)
   {
     wrb.upgradeDataRequest.value(msg.value)(_id, _resultReward);
   }

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -178,7 +178,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     if (requests[_id].drHash != 0) {
       require(
         msg.value == _tallyReward,
-        "Result reward should be equal to txn value (data request was included)"
+        "Result reward should equal txn value (request reward already given)"
       );
       requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
     } else {

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -168,9 +168,23 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward) external payable payingEnough(msg.value, _tallyReward) override {
-    requests[_id].inclusionReward = SafeMath.add(requests[_id].inclusionReward, SafeMath.sub(msg.value, _tallyReward));
-    requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
+  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
+    external
+    payable
+    payingEnough(msg.value, _tallyReward)
+    resultNotIncluded(_id)
+    override
+  {
+    if (requests[_id].drHash != 0) {
+      require(
+        msg.value == _tallyReward,
+        "Result reward should be equal to txn value (data request was included)"
+      );
+      requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
+    } else {
+      requests[_id].inclusionReward = SafeMath.add(requests[_id].inclusionReward, SafeMath.sub(msg.value, _tallyReward));
+      requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
+    }
   }
 
   /// @dev Checks if the data requests from a list are claimable or not.

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -182,7 +182,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
       );
       requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
     } else {
-      requests[_id].inclusionReward = SafeMath.add(requests[_id].inclusionReward, SafeMath.sub(msg.value, _tallyReward));
+      requests[_id].inclusionReward = SafeMath.add(requests[_id].inclusionReward, msg.value - _tallyReward);
       requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
     }
   }

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -178,7 +178,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     if (requests[_id].drHash != 0) {
       require(
         msg.value == _tallyReward,
-        "Result reward should equal txn value (request reward already given)"
+        "Txn value should equal result reward argument (request reward already paid)"
       );
       requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
     } else {

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -23,8 +23,8 @@ contract UsingWitnetTestHelper is UsingWitnet {
     return witnetPostRequest(_request, _requestReward, _tallyReward);
   }
 
-  function _witnetUpgradeRequest(uint256 _id, uint256 _tallyReward) external payable {
-    witnetUpgradeRequest(_id, _tallyReward);
+  function _witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _tallyReward) external payable {
+    witnetUpgradeRequest(_id, _requestReward, _tallyReward);
   }
 
   function _witnetReadResult(uint256 _requestId) external returns(Witnet.Result memory) {

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -353,7 +353,7 @@ contract("UsingWitnet", accounts => {
           from: accounts[0],
           value: transactionValue,
         }),
-        "The sum of rewards should be equal to transaction value"
+        "Transaction value should equal the sum of rewards"
       )
     })
 

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -873,7 +873,7 @@ contract("WRB", accounts => {
             web3.utils.toWei("1", "ether"),
             { from: accounts[1], value: web3.utils.toWei("2", "ether") }
           ),
-          "Result reward should equal txn value (request reward already given)"
+          "Txn value should equal result reward argument (request reward already paid)"
         )
 
         // upgrade data request with valid rewards with DR already included


### PR DESCRIPTION
This PR prevents burning user funds due to non-existent checks in post request and upgrade request  functions, located in both `UsingWitnet` and `WitnetRequestsBoard` contracts.

To discuss what to do with `UsingWitnetBytes` as it has not been properly maintained:

- lacks of some modifiers (e.g. `witnetRequestAccepted`)
- deviates from function signatures used in `UsingWitnet.sol`

Supersedes #73 