### PR TITLE
Add epoch condition in wrb to avoid replay poi attack

### DIFF
--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -236,7 +236,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     // Ensures the request inclusion is reported after the epoch in which the request was posted
     require(
       requests[_id].epoch < _epoch,
-      "the dr inclusion must be reported after the dr is posted into the WRB");
+      "The request inclusion must be reported after it is posted into the WRB");
     // Update the dr epoch
     requests[_id].epoch = _epoch;
 
@@ -278,7 +278,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     absMember(msg.sender)
  {
     // Ensures the result was published in a later block than the request
-    require(requests[_id].epoch <= _epoch, "the result must be reported after the request is included");
+    require(requests[_id].epoch <= _epoch, "The result cannot be reported before the request is included");
     // Update epoch of the request
     requests[_id].epoch = _epoch;
 

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -30,7 +30,8 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     bytes result;
     // Block number at which the DR was claimed for the last time
     uint256 blockNumber;
-    // The epoch of the blockHash in which the last transaction related to the dr has been included
+    // The epoch of the block including the last transaction related to the dr
+    // (postDataRequest, reportDataRequestInclusion, reportResult)
     uint256 epoch;
     uint256 drHash;
     address payable pkhClaim;
@@ -278,6 +279,8 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
  {
     // Ensures the result was published in a later block than the request
     require(requests[_id].epoch <= _epoch, "the result must be reported after the request is included");
+    // Update epoch of the request
+    requests[_id].epoch = _epoch;
 
     // Ensures the result byes do not have zero length
     // This would not be a valid encoding with CBOR and could trigger a reentrancy attack

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -199,8 +199,8 @@ contract("UsingWitnet", accounts => {
       await blockRelay.postNewBlock(block2Hash, epoch, nullHash, resultHash, { from: accounts[0] })
     })
 
-    it("should post the result of the request into the WBI", async () => {
-      const epoch = 0
+    it("should post the result of the request into the WRB", async () => {
+      const epoch = 1
       await returnData(wrb.reportResult(requestId, [], 0, block2Hash, epoch, resultHex, {
         from: accounts[1],
       }))

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -511,7 +511,6 @@ contract("WRB", accounts => {
       const resBytes = web3.utils.fromAscii("This is a result")
       const data1 = "0x" + sha.sha256(web3.utils.hexToBytes(drBytes))
       var dummySybling = 1
-      const epoch = 0
 
       // VRF params
       const publicKey = [data.publicKey.x, data.publicKey.y]
@@ -580,11 +579,11 @@ contract("WRB", accounts => {
       }), "DR already included")
     })
 
-    it("should revert when trying to prove inclusion of a DR in an epoch inferior than the one in which DR was posted", async () => {
+    it("should revert when trying to prove inclusion of a DR in an epoch inferior than" +
+      "the one in which DR was posted", async () => {
       const drBytes = web3.utils.fromAscii("This is a DR5")
       const resBytes = web3.utils.fromAscii("This is a result")
       const data1 = "0x" + sha.sha256(web3.utils.hexToBytes(drBytes))
-      var dummySybling = 1
 
       // VRF params
       const publicKey = [data.publicKey.x, data.publicKey.y]
@@ -631,7 +630,7 @@ contract("WRB", accounts => {
           from: accounts[1],
         })
       await waitForHash(tx2)
-      
+
       var blockHeader2 = "0x" + sha.sha256("block header 2")
       const roots2 = calculateRoots(drBytes, resBytes)
       const epoch2 = 3

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -643,7 +643,7 @@ contract("WRB", accounts => {
       // later than the epoch for which the dr was posted
       await truffleAssert.reverts(wrbInstance.reportDataRequestInclusion(id1, [data1], 0, blockHeader1, 0, {
         from: accounts[0],
-      }), "the dr inclusion must be reported after the dr is posted into the WRB")
+      }), "The request inclusion must be reported after it is posted into the WRB")
     })
 
     it("should revert when reporting a result for a dr for which its inclusion was not reported yet", async () => {
@@ -835,7 +835,7 @@ contract("WRB", accounts => {
       // revert when reporting the result for an epoch inferior than the one of the dr inclusion
       await truffleAssert.reverts(
         wrbInstance.reportResult(id1, [], 1, blockHeader2, 0, resBytes, { from: accounts[1] }),
-        "the result must be reported after the request is included"
+        "The result cannot be reported before the request is included"
       )
     })
 


### PR DESCRIPTION
This PR solves the problem found by Red4sec #88.  The idea is to check the epoch when reporting a data request, reporting the data request inclusion and reporting the result. It is required that each of the just mentioned functions are executed chronologically.

This PR adds:
- epoch field in DataRequest struct
- require in reportDataRequestInclusion
- require in reportResult
- tests in wrb.js

Fix #88