### PR TITLE
fix: add non-existent checks in libraries and WRB

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,3 +1,4 @@
 node_modules
 contracts/Migrations.sol
 contracts/flattened/Flattened.sol
+test/TestBuffer.sol

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -14,6 +14,12 @@ library BufferLib {
     uint32 cursor;
   }
 
+  // Ensures we access an existing index in an array
+  modifier notOutOfBounds(uint32 index, uint256 length) {
+    require(index < length, "Tried to read from a consumed Buffer (must rewind it first)");
+    _;
+  }
+
   /**
   * @notice Read and consume a certain amount of bytes from the buffer.
   * @param _buffer An instance of `BufferLib.Buffer`.
@@ -51,7 +57,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The next byte in the buffer counting from the cursor position.
   */
-  function next(Buffer memory _buffer) internal pure returns (byte) {
+  function next(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor, _buffer.data.length) returns (byte) {
     // Return the byte at the position marked by the cursor and advance the cursor all at once
     return _buffer.data[_buffer.cursor++];
   }
@@ -100,7 +106,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint8` value of the next byte in the buffer counting from the cursor position.
   */
-  function readUint8(Buffer memory _buffer) internal pure returns (uint8) {
+  function readUint8(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor, _buffer.data.length) returns (uint8) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint8 value;
@@ -117,7 +123,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint16` value of the next 2 bytes in the buffer counting from the cursor position.
   */
-  function readUint16(Buffer memory _buffer) internal pure returns (uint16) {
+  function readUint16(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor + 1, _buffer.data.length) returns (uint16) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint16 value;
@@ -134,7 +140,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint32` value of the next 4 bytes in the buffer counting from the cursor position.
   */
-  function readUint32(Buffer memory _buffer) internal pure returns (uint32) {
+  function readUint32(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor + 3, _buffer.data.length) returns (uint32) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint32 value;
@@ -151,7 +157,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint64` value of the next 8 bytes in the buffer counting from the cursor position.
   */
-  function readUint64(Buffer memory _buffer) internal pure returns (uint64) {
+  function readUint64(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor + 7, _buffer.data.length) returns (uint64) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint64 value;
@@ -168,7 +174,7 @@ library BufferLib {
   * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint128` value of the next 16 bytes in the buffer counting from the cursor position.
   */
-  function readUint128(Buffer memory _buffer) internal pure returns (uint128) {
+  function readUint128(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor + 15, _buffer.data.length) returns (uint128) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint128 value;
@@ -182,10 +188,10 @@ library BufferLib {
 
   /**
   * @notice Read and consume the next 32 bytes from the buffer as an `uint256`.
-  * @param _buffer An instance of `BufferLib.Buffer`.
   * @return The `uint256` value of the next 32 bytes in the buffer counting from the cursor position.
+  * @param _buffer An instance of `BufferLib.Buffer`.
   */
-  function readUint256(Buffer memory _buffer) internal pure returns (uint256) {
+  function readUint256(Buffer memory _buffer) internal pure notOutOfBounds(_buffer.cursor + 31, _buffer.data.length) returns (uint256) {
     bytes memory bytesValue = _buffer.data;
     uint32 offset = _buffer.cursor;
     uint256 value;

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -202,6 +202,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
       uint256 index = _ids[i];
       validIds[i] = (dataRequestCanBeClaimed(requests[index])) &&
         requests[index].drHash == 0 &&
+        index < requests.length &&
         requests[index].result.length == 0;
     }
 
@@ -287,6 +288,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @param _id The unique identifier of the data request.
   /// @return The result of the data request as bytes.
   function readDataRequest(uint256 _id) external view returns(bytes memory) {
+    require(requests.length > _id, "Id not found");
     return requests[_id].dr;
   }
 
@@ -294,6 +296,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @param _id The unique identifier of the data request.
   /// @return The result of the DR
   function readResult(uint256 _id) external view override returns(bytes memory) {
+    require(requests.length > _id, "Id not found");
     return requests[_id].result;
   }
 
@@ -301,6 +304,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DataRequest transaction in Witnet.
   function readDrHash(uint256 _id) external view override returns(uint256) {
+    require(requests.length > _id, "Id not found");
     return requests[_id].drHash;
   }
 

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -834,6 +834,7 @@ contract("WRB", accounts => {
           "The last block number updated was higher than the one provided"
         )
       })
+
     it("should revert while upgrading the rewards with wrong values or if the result was reported",
       async () => {
         const drBytes = web3.utils.fromAscii("This is a DR7")
@@ -927,6 +928,14 @@ contract("WRB", accounts => {
         )
       }
     )
+
+    it("should revert reading data for non-existent Ids",
+      async () => {
+        // revert when reporting the same result
+        await truffleAssert.reverts(wrbInstance.readDataRequest(2000), "Id not found")
+        await truffleAssert.reverts(wrbInstance.readDrHash(2000), "Id not found")
+        await truffleAssert.reverts(wrbInstance.readResult(2000), "Id not found")
+      })
   })
 })
 


### PR DESCRIPTION
This PR adds some checks that were not existent in the smart contracts. Some of which have not been fixed:

Witnet-ethereum-block-relay\contracts\CentralizedBlockRelay.sol:156-157
In flushSlot() function, it is not verified that values are the expected. It should be verified -> **Non-existent (probably a mistake in the report)** 

Witnet-ethereum-bridge\contracts\ActiveBridgeSetLib.sol:50-51
In flushSlot() function, it is not verified that values are the expected. It should be verified
that the epoch is the consecutive or the same as the last inserted. -> **Verified in UpdateABS from WRB**

• Witnet-ethereum-bridge\contracts\WitnetRequestsBoardProxy.sol:120-125
When exiting for loop, instead of returning the default values. We recommend including a
revert() in order to avoid returning non-existent "controllers". -> **Default controllers can never be returned according to the algorithm (always an existent controller is returned)**

• Witnet-ethereum-bridge\contracts\WitnetRequestsBoard.sol:269-270
Witnet-ethereum-bridge\contracts\UsingWitnet.sol:66-67 -> **Fixed by #86**

• Witnet-ethereum-bridge\contracts\Witnet.sol:418-424
This function converts an array to a string but does not work correctly when the size is
greater than 3 digits. It should be verified and reverted when it exceeds this limit. -> **By definition the function fails if a string with more than 3 digits is inserted. This is expected behavior, and we do not pretend such a function to revert if more than 3 digits are inserted as that would prevent us from reading useful errors from Witnet.