### PR TITLE
Avoid overflow

### DIFF
--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -164,6 +164,7 @@ library ActiveBridgeSetLib {
   /// @param _abs The Active Bridge Set to be flushed.
   /// @param _address The address to be flushed.
   function flushIdentity(ActiveBridgeSet storage _abs, address _address) private {
+    require(absMembership(_abs, _address) == true, "The address already out of the ARS");
     // Decrement the count of an identity, and if it reaches 0, delete it and update `nextActiveIdentities`count
     _abs.identityCount[_address]--;
     if (_abs.identityCount[_address] == 0) {

--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -164,7 +164,7 @@ library ActiveBridgeSetLib {
   /// @param _abs The Active Bridge Set to be flushed.
   /// @param _address The address to be flushed.
   function flushIdentity(ActiveBridgeSet storage _abs, address _address) private {
-    require(absMembership(_abs, _address) == true, "The address already out of the ARS");
+    require(absMembership(_abs, _address), "The identity address is already out of the ARS");
     // Decrement the count of an identity, and if it reaches 0, delete it and update `nextActiveIdentities`count
     _abs.identityCount[_address]--;
     if (_abs.identityCount[_address] == 0) {

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -74,6 +74,7 @@ library BufferLib {
   function seek(Buffer memory _buffer, uint32 _offset, bool _relative) internal pure returns (uint32) {
     // Deal with relative offsets
     if (_relative) {
+      require(_offset + _buffer.cursor > _offset, "The sum _offset caused an overflow");
       _offset += _buffer.cursor;
     }
     // Make sure not to read out of the bounds of the original bytes

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -74,7 +74,7 @@ library BufferLib {
   function seek(Buffer memory _buffer, uint32 _offset, bool _relative) internal pure returns (uint32) {
     // Deal with relative offsets
     if (_relative) {
-      require(_offset + _buffer.cursor > _offset, "The sum _offset caused an overflow");
+      require(_offset + _buffer.cursor > _offset, "Integer overflow when seeking");
       _offset += _buffer.cursor;
     }
     // Make sure not to read out of the bounds of the original bytes


### PR DESCRIPTION
This PR avoids overflows to occur in:

 - BufferLib.sol
 - ActiveBridgeSetLib.sol

Closes #98 and #99 