### PR TITLE
Claim verification

### DIFF
--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -97,6 +97,13 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     require(requests[_id].drHash != 0, "DR not yet included");
     _;
   }
+
+  // Ensures the DR inclusion has been already reported
+  modifier drClaimed(uint256 _id) {
+    require(requests[_id].timestamp != 0, "DR not yet claimed");
+    _;
+  }
+
   // Ensures the result has not been reported yet
   modifier resultNotIncluded(uint256 _id) {
     require(requests[_id].result.length == 0, "Result already included");
@@ -220,6 +227,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     uint256 _blockHash,
     uint256 _epoch)
     external
+    drClaimed(_id)
     drNotIncluded(_id)
  {
     uint256 drOutputHash = uint256(sha256(requests[_id].dr));

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -503,7 +503,7 @@ contract("WRB", accounts => {
       // Should revert when reporting the inclusion since the dr has not been claimed
       await truffleAssert.reverts(wrbInstance.reportDataRequestInclusion(id1, [dummySybling], 1, blockHeader1, epoch, {
         from: accounts[1],
-      }), "DR not yet claimed")
+      }), "Data Request has not yet been claimed")
     })
 
     it("should revert when trying to report a dr inclusion that was already reported", async () => {


### PR DESCRIPTION
This PR adds a modifier in `ReportDataRequestInclusion` so that reverts if the data request has not been claimed. It also adds a test.

Closes #101 