### PR TITLE
Gas optimizations

### DIFF
--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -11,7 +11,7 @@ library ActiveBridgeSetLib {
   uint8 public constant CLAIM_BLOCK_PERIOD = 8;
 
   // Number of activity slots in the ABS
-  uint16 public constant ACTIVITY_LENGTH = 100;
+  uint8 public constant ACTIVITY_LENGTH = 100;
 
   struct ActiveBridgeSet {
     // Mapping of activity slots with participating identities
@@ -96,13 +96,14 @@ library ActiveBridgeSetLib {
   /// @param _abs The Active Bridge Set structure containing the last block.
   /// @param _blockNumber The block number from which to get the current slot.
   /// @return (currentSlot, lastSlot, overflow), where overflow implies the block difference &gt; CLAIM_BLOCK_PERIOD* ACTIVITY_LENGTH.
-  function getSlots(ActiveBridgeSet storage _abs, uint256 _blockNumber) private view returns (uint16, uint16, bool) {
+  function getSlots(ActiveBridgeSet storage _abs, uint256 _blockNumber) private view returns (uint8, uint8, bool) {
     // Get current activity slot number
-    uint16 currentSlot = uint16((_blockNumber / CLAIM_BLOCK_PERIOD) % ACTIVITY_LENGTH);
+    uint8 currentSlot = uint8((_blockNumber / CLAIM_BLOCK_PERIOD) % ACTIVITY_LENGTH);
     // Get last actitivy slot number
-    uint16 lastSlot = uint16((_abs.lastBlockNumber / CLAIM_BLOCK_PERIOD) % ACTIVITY_LENGTH);
+    uint8 lastSlot = uint8((_abs.lastBlockNumber / CLAIM_BLOCK_PERIOD) % ACTIVITY_LENGTH);
     // Check if there was an activity slot overflow
-    bool overflow = (_blockNumber - _abs.lastBlockNumber) >= CLAIM_BLOCK_PERIOD * ACTIVITY_LENGTH;
+    // `ACTIVITY_LENGTH` is changed to `uint16` here to ensure the multiplication doesn't overflow silently
+    bool overflow = (_blockNumber - _abs.lastBlockNumber) >= CLAIM_BLOCK_PERIOD * uint16(ACTIVITY_LENGTH);
 
     return (currentSlot, lastSlot, overflow);
   }

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -9,7 +9,7 @@ pragma solidity >=0.5.3 <0.7.0;
 library BufferLib {
   struct Buffer {
     bytes data;
-    uint64 cursor;
+    uint32 cursor;
   }
 
   /**
@@ -18,12 +18,12 @@ library BufferLib {
   * @param _length How many bytes to read and consume from the buffer.
   * @return A `bytes memory` containing the first `_length` bytes from the buffer, counting from the cursor position.
   */
-  function read(Buffer memory _buffer, uint64 _length) internal pure returns (bytes memory) {
+  function read(Buffer memory _buffer, uint32 _length) internal pure returns (bytes memory) {
     // Make sure not to read out of the bounds of the original bytes
     require(_buffer.cursor + _length <= _buffer.data.length, "Not enough bytes in buffer when reading");
     // Create a new `bytes memory` value and copy the desired bytes into it
     bytes memory value = new bytes(_length);
-    for (uint64 index = 0; index < _length; index++) {
+    for (uint32 index = 0; index < _length; index++) {
       value[index] = next(_buffer);
     }
 
@@ -48,15 +48,14 @@ library BufferLib {
   * buffer (`true`).
   * @return The final position of the cursor (will equal `_offset` if `_relative` is `false`).
   */
-  function seek(Buffer memory _buffer, uint64 _offset, bool _relative) internal pure returns (uint64) {
-    uint64 newCursor = _offset;
+  function seek(Buffer memory _buffer, uint32 _offset, bool _relative) internal pure returns (uint32) {
     // Deal with relative offsets
     if (_relative == true) {
-      newCursor += _buffer.cursor;
+      _offset += _buffer.cursor;
     }
     // Make sure not to read out of the bounds of the original bytes
-    require(newCursor < _buffer.data.length, "Not enough bytes in buffer when seeking");
-    _buffer.cursor = newCursor;
+    require(_offset < _buffer.data.length, "Not enough bytes in buffer when seeking");
+    _buffer.cursor = _offset;
     return _buffer.cursor;
   }
 
@@ -67,7 +66,7 @@ library BufferLib {
   * @param _relativeOffset How many bytes to move the cursor forward.
   * @return The final position of the cursor.
   */
-  function seek(Buffer memory _buffer, uint64 _relativeOffset) internal pure returns (uint64) {
+  function seek(Buffer memory _buffer, uint32 _relativeOffset) internal pure returns (uint32) {
     return seek(_buffer, _relativeOffset, true);
   }
 
@@ -86,7 +85,7 @@ library BufferLib {
   */
   function readUint8(Buffer memory _buffer) internal pure returns (uint8) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint8 value;
     assembly {
       value := mload(add(add(bytesValue, 1), offset))
@@ -103,7 +102,7 @@ library BufferLib {
   */
   function readUint16(Buffer memory _buffer) internal pure returns (uint16) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint16 value;
     assembly {
       value := mload(add(add(bytesValue, 2), offset))
@@ -120,7 +119,7 @@ library BufferLib {
   */
   function readUint32(Buffer memory _buffer) internal pure returns (uint32) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint32 value;
     assembly {
       value := mload(add(add(bytesValue, 4), offset))
@@ -137,7 +136,7 @@ library BufferLib {
   */
   function readUint64(Buffer memory _buffer) internal pure returns (uint64) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint64 value;
     assembly {
       value := mload(add(add(bytesValue, 8), offset))
@@ -154,7 +153,7 @@ library BufferLib {
   */
   function readUint128(Buffer memory _buffer) internal pure returns (uint128) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint128 value;
     assembly {
       value := mload(add(add(bytesValue, 16), offset))
@@ -171,7 +170,7 @@ library BufferLib {
   */
   function readUint256(Buffer memory _buffer) internal pure returns (uint256) {
     bytes memory bytesValue = _buffer.data;
-    uint64 offset = _buffer.cursor;
+    uint32 offset = _buffer.cursor;
     uint256 value;
     assembly {
       value := mload(add(add(bytesValue, 32), offset))

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -64,7 +64,7 @@ library BufferLib {
   */
   function seek(Buffer memory _buffer, uint32 _offset, bool _relative) internal pure returns (uint32) {
     // Deal with relative offsets
-    if (_relative == true) {
+    if (_relative) {
       _offset += _buffer.cursor;
     }
     // Make sure not to read out of the bounds of the original bytes

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.5.3 <0.7.0;
  * @title A convenient wrapper around the `bytes memory` type that exposes a buffer-like interface
  * @notice The buffer has an inner cursor that tracks the final offset of every read, i.e. any subsequent read will
  * start with the byte that goes right after the last one in the previous read.
+ * @dev `uint32` is used here for `cursor` because `uint16` would only enable seeking up to 8KB, which could in some
+ * theoretical use cases be exceeded. Conversely, `uint32` supports up to 512MB, which cannot credibly be exceeded.
  */
 library BufferLib {
   struct Buffer {

--- a/contracts/BufferLib.sol
+++ b/contracts/BufferLib.sol
@@ -28,15 +28,15 @@ library BufferLib {
     uint32 offset = _buffer.cursor;
 
     // Get raw pointers for source and destination
-    uint source_pointer;
-    uint destination_pointer;
+    uint sourcePointer;
+    uint destinationPointer;
     assembly {
-      source_pointer := add(add(source, 32), offset)
-      destination_pointer := add(destination, 32)
+      sourcePointer := add(add(source, 32), offset)
+      destinationPointer := add(destination, 32)
     }
 
     // Copy `_length` bytes from source to destination
-    memcpy(destination_pointer, source_pointer, uint(_length));
+    memcpy(destinationPointer, sourcePointer, uint(_length));
 
     // Move the cursor forward by `_length` bytes
     seek(_buffer, _length, true);
@@ -62,6 +62,7 @@ library BufferLib {
   * buffer (`true`).
   * @return The final position of the cursor (will equal `_offset` if `_relative` is `false`).
   */
+  // solium-disable-next-line security/no-assign-params
   function seek(Buffer memory _buffer, uint32 _offset, bool _relative) internal pure returns (uint32) {
     // Deal with relative offsets
     if (_relative) {
@@ -241,9 +242,10 @@ library BufferLib {
   * @param _src Address to the source memory.
   * @param _len How many bytes to copy.
   */
+  // solium-disable-next-line security/no-assign-params
   function memcpy(uint _dest, uint _src, uint _len) private pure {
     // Copy word-length chunks while possible
-    for(; _len >= 32; _len -= 32) {
+    for (; _len >= 32; _len -= 32) {
       assembly {
         mstore(_dest, mload(_src))
       }

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -39,17 +39,17 @@ library CBOR {
       bytes memory bytesData;
 
       // These checks look repetitive but the equivalent loop would be more expensive.
-      uint64 itemLength = readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType);
+      uint32 itemLength = uint32(readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType));
       if (itemLength < UINT64_MAX) {
         bytesData = abi.encodePacked(bytesData, _cborValue.buffer.read(itemLength));
-        itemLength = readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType);
+        itemLength = uint32(readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType));
         if (itemLength < UINT64_MAX) {
           bytesData = abi.encodePacked(bytesData, _cborValue.buffer.read(itemLength));
         }
       }
       return bytesData;
     } else {
-      return _cborValue.buffer.read(_cborValue.len);
+      return _cborValue.buffer.read(uint32(_cborValue.len));
     }
   }
 

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -290,6 +290,7 @@ library CBOR {
 
   // Read a text string of a given length from a buffer. Returns a `bytes memory` value for the sake of genericness,
   // but it can be easily casted into a string with `string(result)`.
+  // solium-disable-next-line security/no-assign-params
   function readText(BufferLib.Buffer memory _buffer, uint64 _length) private pure returns(bytes memory) {
     bytes memory result;
     for (uint64 index = 0; index < _length; index++) {

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -317,9 +317,4 @@ library CBOR {
     }
     return result;
   }
-
-  // This simply seeks a buffer's internal pointer until a break is found.
-  function readBreak(BufferLib.Buffer memory _buffer) private pure returns(bool) {
-    return _buffer.next() == 0xff;
-  }
 }

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -293,25 +293,24 @@ library CBOR {
   // but it can be easily casted into a string with `string(result)`.
   function readText(BufferLib.Buffer memory _buffer, uint64 _length) private pure returns(bytes memory) {
     bytes memory result;
-    uint64 length = _length;
-    for (uint64 index = 0; index < length; index++) {
+    for (uint64 index = 0; index < _length; index++) {
       uint8 value = _buffer.readUint8();
       if (value & 0x80 != 0) {
         if (value < 0xe0) {
           value = (value & 0x1f) << 6 |
             (_buffer.readUint8() & 0x3f);
-          length -= 1;
+          _length -= 1;
         } else if (value < 0xf0) {
           value = (value & 0x0f) << 12 |
             (_buffer.readUint8() & 0x3f) << 6 |
             (_buffer.readUint8() & 0x3f);
-          length -= 2;
+          _length -= 2;
         } else {
           value = (value & 0x0f) << 18 |
             (_buffer.readUint8() & 0x3f) << 12 |
             (_buffer.readUint8() & 0x3f) << 6  |
             (_buffer.readUint8() & 0x3f);
-          length -= 3;
+          _length -= 3;
         }
       }
       result = abi.encodePacked(result, value);

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -37,16 +37,15 @@ library CBOR {
     _cborValue.len = readLength(_cborValue.buffer, _cborValue.additionalInformation);
     if (_cborValue.len == UINT64_MAX) {
       bytes memory bytesData;
-      bool done;
-      uint8 limit = 0;
-      while (!done && limit < 2) {
-        uint64 itemLength = readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType);
+
+      // These checks look repetitive but the equivalent loop would be more expensive.
+      uint64 itemLength = readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType);
+      if (itemLength < UINT64_MAX) {
+        bytesData = abi.encodePacked(bytesData, _cborValue.buffer.read(itemLength));
+        itemLength = readIndefiniteStringLength(_cborValue.buffer, _cborValue.majorType);
         if (itemLength < UINT64_MAX) {
           bytesData = abi.encodePacked(bytesData, _cborValue.buffer.read(itemLength));
-        } else {
-          done = true;
         }
-        limit++;
       }
       return bytesData;
     } else {

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -176,13 +176,7 @@ library Witnet {
    */
   function asErrorCode(Result memory _result) public pure returns(ErrorCodes) {
     uint64[] memory error = asRawError(_result);
-
-    // Decode the error code only if it belongs to the `ErrorCodes` enum — otherwise, default to `ErrorCodes.Unknown`
-    if (error[0] <= uint8(ErrorCodes.Size)) {
-      return ErrorCodes(error[0]);
-    } else {
-      return ErrorCodes.Unknown;
-    }
+    return supportedErrorOrElseUnknown(error[0]);
   }
 
   /**
@@ -192,15 +186,8 @@ library Witnet {
    */
   function asErrorMessage(Result memory _result) public pure returns(ErrorCodes, string memory) {
     uint64[] memory error = asRawError(_result);
-    ErrorCodes errorCode;
+    ErrorCodes errorCode = supportedErrorOrElseUnknown(error[0]);
     bytes memory errorMessage;
-
-    // Decode the error code only if it belongs to the `ErrorCodes` enum — otherwise, default to `ErrorCodes.Unknown`
-    if (error[0] <= uint8(ErrorCodes.Size)) {
-      errorCode = ErrorCodes(error[0]);
-    } else {
-      errorCode = ErrorCodes.Unknown;
-    }
 
     if (errorCode == ErrorCodes.SourceScriptNotCBOR) {
       errorMessage = abi.encodePacked("Source script #", utoa(error[1]), " was not a valid CBOR value");
@@ -397,6 +384,20 @@ library Witnet {
       return "tally";
     } else {
       return "unknown";
+    }
+  }
+
+  /**
+  * @notice Get an `ErrorCodes` item from its `uint64` discriminant, or default to `ErrorCodes.Unknown` if it doesn't
+  * exist.
+  * @param _discriminant The numeric identifier of an error.
+  * @return A member of `ErrorCodes`.
+  */
+  function supportedErrorOrElseUnknown(uint64 _discriminant) private pure returns(ErrorCodes) {
+    if (_discriminant < uint8(ErrorCodes.Size)) {
+      return ErrorCodes(_discriminant);
+    } else {
+      return ErrorCodes.Unknown;
     }
   }
 

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -73,7 +73,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
         _poe,
         _publicKey,
         _uPoint,
-        _vPointHelpers) == true,
+        _vPointHelpers),
       "Not a valid PoE");
     _;
   }
@@ -82,7 +82,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   modifier validSignature(
     uint256[2] memory _publicKey,
     bytes memory addrSignature) {
-    require(verifySig(abi.encodePacked(msg.sender), _publicKey, addrSignature) == true, "Not a valid signature");
+    require(verifySig(abi.encodePacked(msg.sender), _publicKey, addrSignature), "Not a valid signature");
     _;
   }
 
@@ -115,13 +115,13 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
         _poe,
         getLastBeacon(),
         _uPoint,
-        _vPointHelpers) == true,
+        _vPointHelpers),
       "Not a valid VRF");
     _;
   }
   // Ensures the address belongs to the active bridge set
   modifier absMember(address _address) {
-    require(abs.absMembership(_address) == true, "Not a member of the ABS");
+    require(abs.absMembership(_address), "Not a member of the ABS");
     _;
   }
 

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -154,15 +154,11 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     // The initial length of the `requests` array will become the ID of the request for everything related to the WRB
     uint256 id = requests.length;
 
-    // Create a new `DataRequest` object and initialize all the fields
+    // Create a new `DataRequest` object and initialize all the non-default fields
     DataRequest memory request;
     request.dr = _serialized;
     request.inclusionReward = SafeMath.sub(msg.value, _tallyReward);
     request.tallyReward = _tallyReward;
-    request.result = "";
-    request.timestamp = 0;
-    request.drHash = 0;
-    request.pkhClaim = address(0);
 
     // Push the new request into the contract state
     requests.push(request);


### PR DESCRIPTION
Multiple gas optimizations as suggested by red4sec.

Only three of their suggestions are NOT included in this PR. Explanations below:

- **Witnet-ethereum-bridge\contracts\Witnet.sol:432-433 - Could be uint16 instead of uint64.**
        It would be antiergonomic to force the caller to do the uint64 → uint16 trimming, because this is always used on uint64 values because that's the API of our CBOR arrays.

- **Witnet-ethereum-bridge\contracts\Witnet.sol:299-300 - Use bytes instead of uint64.**
        It is a convention in Witnet that errors are returned as CBOR arrays containing unsigned integers. As the only unsigned integer type currently supported is `uint64`, we are force to use that.
        If you want the raw bytes representation of the error, you already have `result.cborValue.buffer.data`

- **Witnet-ethereum-bridge\contracts\WitnetRequestsBoard.sol:149** - Delete requests once their result is read.
        Just not yet (requires discussion and many changes on multiple repos and docs)

