### PR TITLE
fix: use 0.6.4 solidity version

### DIFF
--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.3 <0.7.0;
+pragma solidity 0.6.4;
 
 import "./WitnetRequestsBoardInterface.sol";
 


### PR DESCRIPTION
The `WitnetRequestBoardProxy`  contract was not using a fixed solidity compiler version as it should.