### PR TITLE
fix: update ABS activity checks

### DIFF
--- a/contracts/ActiveBridgeSetLib.sol
+++ b/contracts/ActiveBridgeSetLib.sol
@@ -28,8 +28,8 @@ library ActiveBridgeSetLib {
     uint256 lastBlockNumber;
   }
 
-  modifier validBlockNumber(uint256 _currentBlock, uint256 _lastBlock) {
-    require (_currentBlock >= _lastBlock, "The last updated block was higher than the one provided");
+  modifier validBlockNumber(uint256 _blockFromArguments, uint256 _blockFromContractState) {
+    require (_blockFromArguments >= _blockFromContractState, "The provided block is older than the last updated block");
     _;
   }
 

--- a/test/TestActiveBridgeSet.sol
+++ b/test/TestActiveBridgeSet.sol
@@ -138,7 +138,7 @@ contract TestActiveBridgeSet {
     fakeAbs.lastBlockNumber = 1;
     TestActiveBridgeSet(address(throwProxy)).errorUpdateABS(0);
     (r, error) = throwProxy.execute.gas(100000)();
-    Assert.isFalse(r, "The last updated block was higher than the one provided");
+    Assert.isFalse(r, "The provided block is older than the last updated block");
   }
 
   function testNotValidPushBlockNumber() external {
@@ -148,7 +148,7 @@ contract TestActiveBridgeSet {
     fakeAbs.lastBlockNumber = 1;
     TestActiveBridgeSet(address(throwProxy)).errorPushABS(address(0), 0);
     (r, error) = throwProxy.execute.gas(100000)();
-    Assert.isFalse(r, "The last updated block was higher than the one provided");
+    Assert.isFalse(r, "The provided block is older than the last updated block");
   }
 
   function errorUpdateABS(uint256 _blockNumber) public {

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -831,7 +831,7 @@ contract("WRB", accounts => {
         await waitForHash(tx1)
         await truffleAssert.reverts(
           wrbInstance.updateAbsActivity(newBlock),
-          "The last updated block was higher than the one provided"
+          "The provided block is older than the last updated block"
         )
       })
 


### PR DESCRIPTION
This issue moves checking whether the block number provided is higher than the last one inserted to the ABS library.Closes issue 13.10 from the security audit