### PR TITLE
fix: check if error code length is zero

### DIFF
--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 
 import "./BufferLib.sol";

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -178,6 +178,10 @@ library Witnet {
    */
   function asErrorCode(Result memory _result) public pure returns(ErrorCodes) {
     uint64[] memory error = asRawError(_result);
+    if (error.length == 0) {
+      return ErrorCodes.Unknown;
+    }
+
     return supportedErrorOrElseUnknown(error[0]);
   }
 
@@ -189,18 +193,21 @@ library Witnet {
    */
   function asErrorMessage(Result memory _result) public pure returns(ErrorCodes, string memory) {
     uint64[] memory error = asRawError(_result);
+    if (error.length == 0) {
+      return (ErrorCodes.Unknown, "Unknown error (no error code)");
+    }
     ErrorCodes errorCode = supportedErrorOrElseUnknown(error[0]);
     bytes memory errorMessage;
 
-    if (errorCode == ErrorCodes.SourceScriptNotCBOR) {
+    if (errorCode == ErrorCodes.SourceScriptNotCBOR && error.length >= 2) {
       errorMessage = abi.encodePacked("Source script #", utoa(error[1]), " was not a valid CBOR value");
-    } else if (errorCode == ErrorCodes.SourceScriptNotArray) {
+    } else if (errorCode == ErrorCodes.SourceScriptNotArray && error.length >= 2) {
       errorMessage = abi.encodePacked("The CBOR value in script #", utoa(error[1]), " was not an Array of calls");
-    } else if (errorCode == ErrorCodes.SourceScriptNotRADON) {
+    } else if (errorCode == ErrorCodes.SourceScriptNotRADON && error.length >= 2) {
       errorMessage = abi.encodePacked("The CBOR value in script #", utoa(error[1]), " was not a valid RADON script");
-    } else if (errorCode == ErrorCodes.RequestTooManySources) {
+    } else if (errorCode == ErrorCodes.RequestTooManySources && error.length >= 2) {
       errorMessage = abi.encodePacked("The request contained too many sources (", utoa(error[1]), ")");
-    } else if (errorCode == ErrorCodes.ScriptTooManyCalls) {
+    } else if (errorCode == ErrorCodes.ScriptTooManyCalls && error.length >= 4) {
       errorMessage = abi.encodePacked(
         "Script #",
         utoa(error[2]),
@@ -210,7 +217,7 @@ library Witnet {
         utoa(error[3]),
         ")"
       );
-    } else if (errorCode == ErrorCodes.UnsupportedOperator) {
+    } else if (errorCode == ErrorCodes.UnsupportedOperator && error.length >= 5) {
       errorMessage = abi.encodePacked(
       "Operator code 0x",
         utohex(error[4]),
@@ -222,7 +229,7 @@ library Witnet {
         stageName(error[1]),
         " stage is not supported"
       );
-    } else if (errorCode == ErrorCodes.HTTP) {
+    } else if (errorCode == ErrorCodes.HTTP && error.length >= 3) {
       errorMessage = abi.encodePacked(
         "Source #",
         utoa(error[1]),
@@ -231,13 +238,13 @@ library Witnet {
         utoa(error[2] % 100 / 10),
         utoa(error[2] % 10)
       );
-    } else if (errorCode == ErrorCodes.RetrievalTimeout) {
+    } else if (errorCode == ErrorCodes.RetrievalTimeout && error.length >= 2) {
       errorMessage = abi.encodePacked(
         "Source #",
         utoa(error[1]),
         " could not be retrieved because of a timeout."
       );
-    } else if (errorCode == ErrorCodes.Underflow) {
+    } else if (errorCode == ErrorCodes.Underflow && error.length >= 5) {
       errorMessage = abi.encodePacked(
         "Underflow at operator code 0x",
         utohex(error[4]),
@@ -249,7 +256,7 @@ library Witnet {
         stageName(error[1]),
         " stage"
       );
-    } else if (errorCode == ErrorCodes.Overflow) {
+    } else if (errorCode == ErrorCodes.Overflow && error.length >= 5) {
       errorMessage = abi.encodePacked(
         "Overflow at operator code 0x",
         utohex(error[4]),
@@ -261,7 +268,7 @@ library Witnet {
         stageName(error[1]),
         " stage"
       );
-    } else if (errorCode == ErrorCodes.DivisionByZero) {
+    } else if (errorCode == ErrorCodes.DivisionByZero && error.length >= 5) {
       errorMessage = abi.encodePacked(
         "Division by zero at operator code 0x",
         utohex(error[4]),

--- a/contracts/Witnet.sol
+++ b/contracts/Witnet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 
 import "./CBOR.sol";

--- a/test/TestWitnet.sol
+++ b/test/TestWitnet.sol
@@ -23,6 +23,7 @@ contract WitnetTest {
 
   // Test decoding of `RadonError` error codes
   function testErrorCodes() external {
+    Witnet.ErrorCodes errorCodeEmpty = Witnet.resultFromCborBytes(hex"D82780").asErrorCode();
     Witnet.ErrorCodes errorCode0x00 = Witnet.resultFromCborBytes(hex"D8278100").asErrorCode();
     Witnet.ErrorCodes errorCode0x01 = Witnet.resultFromCborBytes(hex"D8278101").asErrorCode();
     Witnet.ErrorCodes errorCode0x02 = Witnet.resultFromCborBytes(hex"D8278102").asErrorCode();
@@ -35,6 +36,11 @@ contract WitnetTest {
     Witnet.ErrorCodes errorCode0x40 = Witnet.resultFromCborBytes(hex"D827811840").asErrorCode();
     Witnet.ErrorCodes errorCode0x41 = Witnet.resultFromCborBytes(hex"D827811841").asErrorCode();
     Witnet.ErrorCodes errorCode0x42 = Witnet.resultFromCborBytes(hex"D827811842").asErrorCode();
+    Assert.equal(
+      uint(errorCodeEmpty),
+      uint(Witnet.ErrorCodes.Unknown),
+      "empty error code `[]` should be `Witnet.ErrorCodes.Unknown`"
+    );
     Assert.equal(
       uint(errorCode0x00),
       uint(Witnet.ErrorCodes.Unknown),
@@ -99,6 +105,7 @@ contract WitnetTest {
 
   // Test decoding of `RadonError` error messages
   function testErrorMessages() external {
+    (, string memory errorMessageEmpty) = Witnet.resultFromCborBytes(hex"D82780").asErrorMessage();
     (, string memory errorMessage0x00) = Witnet.resultFromCborBytes(hex"D8278100").asErrorMessage();
     (, string memory errorMessage0x01) = Witnet.resultFromCborBytes(hex"D827820102").asErrorMessage();
     (, string memory errorMessage0x02) = Witnet.resultFromCborBytes(hex"D827820203").asErrorMessage();
@@ -112,6 +119,11 @@ contract WitnetTest {
     (, string memory errorMessage0x41) = Witnet.resultFromCborBytes(hex"D827851841000A0B0C").asErrorMessage();
     (, string memory errorMessage0x42) = Witnet.resultFromCborBytes(hex"D827851842010B0C0D").asErrorMessage();
     (, string memory errorMessage0xFF) = Witnet.resultFromCborBytes(hex"D8278118FF").asErrorMessage();
+    Assert.equal(
+      errorMessageEmpty,
+      "Unknown error (no error code)",
+      "Empty error message `[]` should be properly formatted"
+    );
     Assert.equal(
       errorMessage0x00,
       "Unknown error (0x00)",


### PR DESCRIPTION
This PR checks the case of having an error message with length 0 in the functions `asErrorCode` and `asErrorMessage`.

Additionally, we updated the solidity version of the contracts `CBOR` and `Witnet` to a fixed one `0.6.8`. There should not be a problem with the solidity versions as the Witnet consumer contraacts will inherit `UsingWitnet` (by `is UsingWitnet`) and the `CBOR` and `Witnet` contracts will be just linked. :smile: 

This PR fixes the issue identified by Red4Sec 13.11 (closes #118).