### PR TITLE
Pay block reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The `WitnetRequestsBoard` contract provides the following methods:
   in Witnet with a total reward that equals to msg.value.
   - _inputs_:
     - *_dr*: the bytes corresponding to the Protocol Buffers serialization of the data request output.
+    - *_inclusionReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the data request inclusion.
     - *_tallyReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka __tally__) of the data request.
   - output:
     - *_id*: the unique identifier of the data request.
@@ -29,6 +30,7 @@ The `WitnetRequestsBoard` contract provides the following methods:
   adding more value to it. The new request reward will be increased by `msg.value` minus the difference between the former tally reward and the new tally reward.
   - *_inputs*:
     - *_id*: the unique identifier of the data request.
+    - *_inclusionReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the data request inclusion.
     - *_tallyReward*: the new tally reward. Needs to be equal or greater than the former tally reward.
 
 - **claimDataRequests**:
@@ -91,8 +93,15 @@ The `WitnetRequestsBoard` contract provides the following methods:
 
 - **getLastBeacon**:
   - _description_: queries the block relay contract to get knowledge of the last beacon inserted.
+  _inputs_:
+    - *_id*: the unique identifier of the data request.
   - _output_:
     - the last beacon as byte concatenation of (block_hash||epoch).
+  
+  **getDataRequestPkhClaim**:
+  - _description_: retrieves the last claimer address.
+  - _output_:
+    - the last claimer address of the data request.  
 
 - **requestsCount**:
   - _description_: returns the number of data requests in the WRB.
@@ -115,8 +124,10 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
   specified in `msg.value`.
   - _inputs_:
     - *_dr*: the bytes corresponding to the Protocol Buffers serialization of the data request output.
+    - *_inclusionReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the data request inclusion.
     - *_tallyReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka __tally__) of the data request.
      that is destinated to reward the result inclusion.
+    - *_blockReward*: the amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of block that includes the DR and the result.
   - _output_:
     - *_id*: the unique identifier of the data request.
 
@@ -124,8 +135,9 @@ The `UsingWitnet` contract injects the following methods into the contracts inhe
   - _description_: call to the WRB's `upgradeDataRequest` method to increment the total reward of the data request by adding more value to it. The new request reward will be increased by `msg.value` minus the difference between the former tally reward and the new tally reward.
   - _inputs_:
     - *_id*: the unique identifier of the data request.
-    - *_tallyReward*: the new tally reward. Needs to be equal or greater than the former tally reward.
-
+    - *_inclusionReward*: the amount to be added to the DR inclusion reward.
+    - *_tallyReward*: the amount to be added to the tally reward.
+    - *_blockReward*: the amount to be added to the block reward.
 - **witnetReadResult**:
   - _description_: call to the WRB's `readResult` method to retrieve
    the result of one data request from the WRB.

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -33,9 +33,10 @@ contract UsingWitnet {
   }
 
   // Ensures that user-specified rewards are equal to the total transaction value to prevent users from burning any excess value
-  modifier validRewards(uint256 _requestReward, uint256 _resultReward) {
-    require(_requestReward + _resultReward >= _requestReward, "The sum of rewards overflows");
-    require(msg.value == _requestReward + _resultReward, "Transaction value should equal the sum of rewards");
+  modifier validRewards(uint256 _requestReward, uint256 _resultReward, uint256 _blockReward) {
+    require(_requestReward + _resultReward + _blockReward >= _requestReward, "The sum of rewards overflows");
+
+    require(msg.value == _requestReward + _resultReward + _blockReward, "Transaction value should equal the sum of rewards");
     _;
   }
 
@@ -47,12 +48,12 @@ contract UsingWitnet {
   * @param _resultReward Reward specified for the user which posts back the request result
   * @return Sequencial identifier for the request included in the WitnetRequestsBoard
   */
-  function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward)
+  function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward, uint256 _blockReward)
     internal
-    validRewards(_requestReward, _resultReward)
+    validRewards(_requestReward, _resultReward, _blockReward)
   returns (uint256)
   {
-    return wrb.postDataRequest{value: _requestReward + _resultReward}(address(_request), _resultReward);
+    return wrb.postDataRequest{value: _requestReward + _resultReward + _blockReward}(address(_request), _requestReward, _resultReward);
   }
 
   /**
@@ -79,7 +80,7 @@ contract UsingWitnet {
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _resultReward)
     internal
-    validRewards(_requestReward, _resultReward)
+    validRewards(_requestReward, _resultReward, 0)
   {
     wrb.upgradeDataRequest{value: msg.value}(_id, _resultReward);
   }

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -34,8 +34,9 @@ contract UsingWitnet {
 
   // Ensures that user-specified rewards are equal to the total transaction value to prevent users from burning any excess value
   modifier validRewards(uint256 _requestReward, uint256 _resultReward, uint256 _blockReward) {
-    require(_requestReward + _resultReward + _blockReward >= _requestReward, "The sum of rewards overflows");
-
+    uint256 reqResReward = _requestReward + _resultReward;
+    require(reqResReward >= _requestReward, "The sum of rewards overflows");
+    require(reqResReward + _blockReward >= reqResReward, "The sum of rewards overflows");
     require(msg.value == _requestReward + _resultReward + _blockReward, "Transaction value should equal the sum of rewards");
     _;
   }
@@ -78,11 +79,11 @@ contract UsingWitnet {
   * @param _requestReward Reward specified for the user which posts the request into Witnet
   * @param _resultReward Reward specified for the user which post the Data Request result.
   */
-  function witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _resultReward)
+  function witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _resultReward, uint256 _blockReward)
     internal
-    validRewards(_requestReward, _resultReward, 0)
+    validRewards(_requestReward, _resultReward, _blockReward)
   {
-    wrb.upgradeDataRequest{value: msg.value}(_id, _resultReward);
+    wrb.upgradeDataRequest{value: msg.value}(_id, _requestReward, _resultReward);
   }
 
   /**

--- a/contracts/UsingWitnet.sol
+++ b/contracts/UsingWitnet.sol
@@ -47,6 +47,7 @@ contract UsingWitnet {
   * @param _request An instance of the `Request` contract
   * @param _requestReward Reward specified for the user which posts the request into Witnet
   * @param _resultReward Reward specified for the user which posts back the request result
+  * @param _blockReward Reward specified for the node which reports the block header for verification
   * @return Sequencial identifier for the request included in the WitnetRequestsBoard
   */
   function witnetPostRequest(Request _request, uint256 _requestReward, uint256 _resultReward, uint256 _blockReward)
@@ -78,6 +79,7 @@ contract UsingWitnet {
   * @param _id The sequential identifier of a request that has been previously sent to the WitnetRequestsBoard.
   * @param _requestReward Reward specified for the user which posts the request into Witnet
   * @param _resultReward Reward specified for the user which post the Data Request result.
+  * @param _blockReward Reward specified for the node which reports the block header for verification
   */
   function witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _resultReward, uint256 _blockReward)
     internal

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -276,6 +276,10 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
       _epoch,
       _index,
       requests[_id].drOutputHash), "Invalid PoI");
+    address payable relayer = payable(blockRelay.readRelayerAddress(_blockHash, _epoch));
+    uint256 relayerPayment = requests[_id].blockReward/2;
+    requests[_id].blockReward = requests[_id].blockReward - relayerPayment; 
+    relayer.transfer(relayerPayment);
     requests[_id].pkhClaim.transfer(requests[_id].inclusionReward);
     // Push requests[_id].pkhClaim to abs
     abs.pushActivity(requests[_id].pkhClaim, block.number);
@@ -321,6 +325,8 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
       _epoch,
       _index,
       resHash), "Invalid PoI");
+    address payable relayer = payable(blockRelay.readRelayerAddress(_blockHash, _epoch));
+    relayer.transfer(requests[_id].blockReward);
     msg.sender.transfer(requests[_id].tallyReward);
 
     emit PostedResult(msg.sender, _id);

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -15,20 +15,21 @@ interface WitnetRequestsBoardInterface {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable returns(uint256);
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward.
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward) external payable;
 
   /// @dev Retrieves the DR hash of the id from the WRB.
   /// @param _id The unique identifier of the data request.
   /// @return The hash of the DR
   function readDrHash (uint256 _id) external view returns(uint256);
-
 
   /// @dev Retrieves the result (if already available) of one data request from the WRB.
   /// @param _id The unique identifier of the data request.

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -17,7 +17,7 @@ interface WitnetRequestsBoardInterface {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward) external payable returns(uint256);
+  function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable returns(uint256);
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.

--- a/contracts/WitnetRequestsBoardInterface.sol
+++ b/contracts/WitnetRequestsBoardInterface.sol
@@ -22,7 +22,7 @@ interface WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward) external payable;
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward) external payable;
 
   /// @dev Retrieves the DR hash of the id from the WRB.
   /// @param _id The unique identifier of the data request.

--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -63,11 +63,11 @@ contract WitnetRequestsBoardProxy {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward) external payable {
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward) external payable {
     address wrbAddress;
     uint256 wrbOffset;
     (wrbAddress, wrbOffset) = getController(_id);
-    return witnetRequestsBoardInstance.upgradeDataRequest{value: msg.value}(_id - wrbOffset, _tallyReward);
+    return witnetRequestsBoardInstance.upgradeDataRequest{value: msg.value}(_id - wrbOffset, _inclusionReward, _tallyReward);
   }
 
   /// @dev Retrieves the DR hash of the id from the WRB.

--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -52,11 +52,11 @@ contract WitnetRequestsBoardProxy {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward) external payable returns(uint256) {
+  function postDataRequest(address _requestAddress,  uint256 _inclusionReward, uint256 _tallyReward) external payable returns(uint256) {
     uint256 n = controllers.length;
     uint256 offset = controllers[n - 1].lastId;
     // Update the currentLastId with the id in the controller plus the offSet
-    currentLastId = witnetRequestsBoardInstance.postDataRequest{value: msg.value}(_requestAddress, _tallyReward) + offset;
+    currentLastId = witnetRequestsBoardInstance.postDataRequest{value: msg.value}(_requestAddress, _inclusionReward, _tallyReward) + offset;
     return currentLastId;
   }
 

--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -50,6 +50,7 @@ contract WitnetRequestsBoardProxy {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress,  uint256 _inclusionReward, uint256 _tallyReward) external payable returns(uint256) {
@@ -62,7 +63,8 @@ contract WitnetRequestsBoardProxy {
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward.  
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward) external payable {
     address wrbAddress;
     uint256 wrbOffset;

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -194,6 +194,7 @@ contract MockBlockRelay is BlockRelayInterface {
   function readRelayerAddress(uint256 _blockHash)
     external
     view
+    override
     blockExists(_blockHash)
   returns(address)
   {

--- a/contracts/mocks/MockBlockRelay.sol
+++ b/contracts/mocks/MockBlockRelay.sol
@@ -17,6 +17,8 @@ contract MockBlockRelay is BlockRelayInterface {
     uint256 drHashMerkleRoot;
     // hash of the merkle root of the tallies in Witnet
     uint256 tallyHashMerkleRoot;
+    // address of the relayer
+    address relayerAddress;
   }
 
   struct Beacon {
@@ -157,6 +159,8 @@ contract MockBlockRelay is BlockRelayInterface {
     lastBlock.epoch = _epoch;
     blocks[id].drHashMerkleRoot = _drMerkleRoot;
     blocks[id].tallyHashMerkleRoot = _tallyMerkleRoot;
+    blocks[id].relayerAddress = msg.sender;
+
     emit NewBlock(witnet, id);
   }
 
@@ -182,6 +186,18 @@ contract MockBlockRelay is BlockRelayInterface {
   returns(uint256)
   {
     return blocks[_blockHash].tallyHashMerkleRoot;
+  }
+
+  /// @dev Retrieve address of the relayer that relayed a specific block header.
+  /// @param _blockHash Hash of the block header.
+  /// @return address of the relayer.
+  function readRelayerAddress(uint256 _blockHash)
+    external
+    view
+    blockExists(_blockHash)
+  returns(address)
+  {
+    return blocks[_blockHash].relayerAddress;
   }
 
   /// @dev Verifies the validity of a PoI.

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -60,7 +60,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -18,6 +18,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     address requestAddress;
     uint256 inclusionReward;
     uint256 tallyReward;
+    uint256 blockReward;
     bytes result;
     uint256 timestamp;
     uint256 drHash;
@@ -39,7 +40,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward)
+  function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override
@@ -50,8 +51,9 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
     requests.push(dr);
 
     requests[_id].requestAddress = _requestAddress;
-    requests[_id].inclusionReward = msg.value - _tallyReward;
+    requests[_id].inclusionReward = _inclusionReward;
     requests[_id].tallyReward = _tallyReward;
+    requests[_id].blockReward = msg.value - _inclusionReward - _tallyReward;
     return _id;
   }
 

--- a/contracts/mocks/MockWitnetRequestsBoard.sol
+++ b/contracts/mocks/MockWitnetRequestsBoard.sol
@@ -38,6 +38,7 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward)
@@ -59,13 +60,14 @@ contract MockWitnetRequestsBoard is WitnetRequestsBoardInterface {
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward.
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override
   {
-    requests[_id].inclusionReward += msg.value - _tallyReward;
+    requests[_id].inclusionReward += _inclusionReward ;
     requests[_id].tallyReward += _tallyReward;
   }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "3.2.0",
     "vrf-solidity": "0.2.3",
-    "witnet-ethereum-block-relay": "witnet/witnet-ethereum-block-relay"
+    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#store_relayer_address"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "3.2.0",
     "vrf-solidity": "0.2.3",
-    "witnet-ethereum-block-relay": "girazoki/witnet-ethereum-block-relay#store_relayer_address"
+    "witnet-ethereum-block-relay": "witnet/witnet-ethereum-block-relay"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.5",

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -21,8 +21,8 @@ contract UsingWitnetTestHelper is UsingWitnet {
 
   constructor (address _wrbAddress) public UsingWitnet(_wrbAddress) { }
 
-  function _witnetPostRequest(Request _request, uint256 _requestReward, uint256 _tallyReward) external payable returns(uint256 id) {
-    return witnetPostRequest(_request, _requestReward, _tallyReward);
+  function _witnetPostRequest(Request _request, uint256 _requestReward, uint256 _tallyReward, uint256 _blockReward) external payable returns(uint256 id) {
+    return witnetPostRequest(_request, _requestReward, _tallyReward, _blockReward);
   }
 
   function _witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _tallyReward) external payable {

--- a/test/helpers/UsingWitnetTestHelper.sol
+++ b/test/helpers/UsingWitnetTestHelper.sol
@@ -25,8 +25,8 @@ contract UsingWitnetTestHelper is UsingWitnet {
     return witnetPostRequest(_request, _requestReward, _tallyReward, _blockReward);
   }
 
-  function _witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _tallyReward) external payable {
-    witnetUpgradeRequest(_id, _requestReward, _tallyReward);
+  function _witnetUpgradeRequest(uint256 _id, uint256 _requestReward, uint256 _tallyReward, uint256 _blockReward) external payable {
+    witnetUpgradeRequest(_id, _requestReward, _tallyReward, _blockReward);
   }
 
   function _witnetReadResult(uint256 _requestId) external returns(Witnet.Result memory) {

--- a/test/test_instances/WitnetRequestsBoardV1.sol
+++ b/test/test_instances/WitnetRequestsBoardV1.sol
@@ -24,6 +24,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
     address requestAddress;
     uint256 inclusionReward;
     uint256 tallyReward;
+    uint256 blockReward;
     bytes result;
     uint256 timestamp;
     uint256 drHash;
@@ -64,13 +65,14 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward) external payable override returns(uint256) {
+  function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);
 
     requests[_id].requestAddress = _requestAddress;
-    requests[_id].inclusionReward = msg.value - _tallyReward;
+    requests[_id].inclusionReward = _inclusionReward;
+    requests[_id].blockReward = msg.value - _tallyReward - _inclusionReward;
     requests[_id].tallyReward = _tallyReward;
     requests[_id].result = "";
     requests[_id].timestamp = 0;

--- a/test/test_instances/WitnetRequestsBoardV1.sol
+++ b/test/test_instances/WitnetRequestsBoardV1.sol
@@ -63,6 +63,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
@@ -84,13 +85,14 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward. 
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override
   {
-    requests[_id].inclusionReward += msg.value - _tallyReward;
+    requests[_id].inclusionReward += _inclusionReward;
     requests[_id].tallyReward += _tallyReward;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV1.sol
+++ b/test/test_instances/WitnetRequestsBoardV1.sol
@@ -85,7 +85,7 @@ contract WitnetRequestsBoardV1 is WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override

--- a/test/test_instances/WitnetRequestsBoardV2.sol
+++ b/test/test_instances/WitnetRequestsBoardV2.sol
@@ -85,7 +85,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override

--- a/test/test_instances/WitnetRequestsBoardV2.sol
+++ b/test/test_instances/WitnetRequestsBoardV2.sol
@@ -24,6 +24,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
     address requestAddress;
     uint256 inclusionReward;
     uint256 tallyReward;
+    uint256 blockReward;
     bytes result;
     uint256 timestamp;
     uint256 drHash;
@@ -64,14 +65,15 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward) external payable override returns(uint256) {
+  function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);
 
     requests[_id].requestAddress = _requestAddress;
-    requests[_id].inclusionReward = msg.value - _tallyReward;
+    requests[_id].inclusionReward = _inclusionReward;
     requests[_id].tallyReward = _tallyReward;
+    requests[_id].blockReward = msg.value - _inclusionReward - _tallyReward;
     requests[_id].result = "hello";
     requests[_id].timestamp = 0;
     requests[_id].drHash = 0;

--- a/test/test_instances/WitnetRequestsBoardV2.sol
+++ b/test/test_instances/WitnetRequestsBoardV2.sol
@@ -63,6 +63,7 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
@@ -84,13 +85,14 @@ contract WitnetRequestsBoardV2 is WitnetRequestsBoardInterface {
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward.
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override
   {
-    requests[_id].inclusionReward += msg.value - _tallyReward;
+    requests[_id].inclusionReward += _inclusionReward;
     requests[_id].tallyReward += _tallyReward;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV3.sol
+++ b/test/test_instances/WitnetRequestsBoardV3.sol
@@ -24,6 +24,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
     address requestAddress;
     uint256 inclusionReward;
     uint256 tallyReward;
+    uint256 blockReward;
     bytes result;
     uint256 timestamp;
     uint256 drHash;
@@ -64,14 +65,15 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   /// @param _requestAddress The request contract address which includes the request bytecode.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
-  function postDataRequest(address _requestAddress, uint256 _tallyReward) external payable override returns(uint256) {
+  function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
     uint256 _id = requests.length;
     DataRequest memory dr;
     requests.push(dr);
 
     requests[_id].requestAddress = _requestAddress;
-    requests[_id].inclusionReward = msg.value - _tallyReward;
+    requests[_id].inclusionReward = _inclusionReward;
     requests[_id].tallyReward = _tallyReward;
+    requests[_id].blockReward = msg.value - _inclusionReward -_tallyReward;
     requests[_id].result = "";
     requests[_id].timestamp = 0;
     requests[_id].drHash = 0;

--- a/test/test_instances/WitnetRequestsBoardV3.sol
+++ b/test/test_instances/WitnetRequestsBoardV3.sol
@@ -63,6 +63,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
 
   /// @dev Posts a data request into the WRB in expectation that it will be relayed and resolved in Witnet with a total reward that equals to msg.value.
   /// @param _requestAddress The request contract address which includes the request bytecode.
+  /// @param _inclusionReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the inclusion of the data request.
   /// @param _tallyReward The amount of value that will be detracted from the transaction value and reserved for rewarding the reporting of the final result (aka tally) of the data request.
   /// @return The unique identifier of the data request.
   function postDataRequest(address _requestAddress, uint256 _inclusionReward, uint256 _tallyReward) external payable override returns(uint256) {
@@ -84,13 +85,14 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
 
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
-  /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
+  /// @param _inclusionReward The amount to be added to the inclusion reward.
+  /// @param _tallyReward The amount to be added to the tally reward.
   function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override
   {
-    requests[_id].inclusionReward += msg.value - _tallyReward;
+    requests[_id].inclusionReward += _inclusionReward;
     requests[_id].tallyReward += _tallyReward;
   }
 

--- a/test/test_instances/WitnetRequestsBoardV3.sol
+++ b/test/test_instances/WitnetRequestsBoardV3.sol
@@ -85,7 +85,7 @@ contract WitnetRequestsBoardV3 is WitnetRequestsBoardInterface {
   /// @dev Increments the rewards of a data request by adding more value to it. The new request reward will be increased by msg.value minus the difference between the former tally reward and the new tally reward.
   /// @param _id The unique identifier of the data request.
   /// @param _tallyReward The new tally reward. Needs to be equal or greater than the former tally reward.
-  function upgradeDataRequest(uint256 _id, uint256 _tallyReward)
+  function upgradeDataRequest(uint256 _id, uint256 _inclusionReward, uint256 _tallyReward)
     external
     payable
     override

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -22,7 +22,8 @@ contract("UsingWitnet", accounts => {
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
     const requestReward = 7000000000000000
-    const resultReward = 3000000000000000
+    const resultReward = 1500000000000000
+    const blockReward = 1500000000000000
 
     let witnet, clientContract, wrb, wrbProxy, blockRelay, request, requestId, requestHash, result, blockRelayProxy
     let lastAccount0Balance, lastAccount1Balance
@@ -55,10 +56,15 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should post a Witnet request into the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
-        from: accounts[0],
-        value: requestReward + resultReward,
-      }))
+      requestId = await returnData(clientContract._witnetPostRequest(
+        request.address,
+        requestReward,
+        resultReward,
+        blockReward, {
+          from: accounts[0],
+          value: requestReward + resultReward + blockReward,
+        }
+      ))
       const expectedId = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
       assert.equal(requestId.toString(16), expectedId)
@@ -91,7 +97,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, requestReward + resultReward)
+      assert.equal(wrbBalance, requestReward + resultReward + blockReward)
     })
 
     it("should upgrade the rewards of a existing Witnet request", async () => {
@@ -123,7 +129,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase after rewards upgrade", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, (requestReward + resultReward) * 2)
+      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward)
     })
 
     it("should claim eligibility for relaying the request into Witnet", async () => {
@@ -229,7 +235,8 @@ contract("UsingWitnet", accounts => {
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
     const requestReward = 7000000000000000
-    const resultReward = 3000000000000000
+    const resultReward = 1500000000000000
+    const blockReward = 1500000000000000
 
     let witnet, clientContract, wrb, blockRelay, blockRelayProxy, request, requestId, requestHash, result
 
@@ -258,10 +265,15 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should pass the data request to the wrb", async () => {
-      requestId = await returnData(clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
-        from: accounts[0],
-        value: requestReward + resultReward,
-      }))
+      requestId = await returnData(clientContract._witnetPostRequest(
+        request.address,
+        requestReward,
+        resultReward,
+        blockReward, {
+          from: accounts[0],
+          value: requestReward + resultReward + blockReward,
+        }
+      ))
       assert.equal(requestId.toString(16), "0x0000000000000000000000000000000000000000000000000000000000000001")
     })
 
@@ -346,10 +358,11 @@ contract("UsingWitnet", accounts => {
     it("Should revert if reward amounts are smaller than transaction value", async () => {
       const requestReward = web3.utils.toWei("1", "ether")
       const resultReward = web3.utils.toWei("1", "ether")
+      const blockReward = web3.utils.toWei("0", "ether")
       const transactionValue = web3.utils.toWei("3", "ether")
 
       await truffleAssert.reverts(
-        clientContract._witnetPostRequest(request.address, requestReward, resultReward, {
+        clientContract._witnetPostRequest(request.address, requestReward, resultReward, blockReward, {
           from: accounts[0],
           value: transactionValue,
         }),
@@ -361,7 +374,7 @@ contract("UsingWitnet", accounts => {
       const resultReward = web3.utils.toBN("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
       await truffleAssert.reverts(
-        clientContract._witnetPostRequest(request.address, resultReward, 1, {
+        clientContract._witnetPostRequest(request.address, resultReward, 1, 1, {
           from: accounts[0],
           value: 0,
         }),

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -129,7 +129,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase after rewards upgrade", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward*2)
+      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward * 2)
     })
 
     it("should claim eligibility for relaying the request into Witnet", async () => {

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -101,9 +101,9 @@ contract("UsingWitnet", accounts => {
     })
 
     it("should upgrade the rewards of a existing Witnet request", async () => {
-      await returnData(clientContract._witnetUpgradeRequest(requestId, requestReward, resultReward, {
+      await returnData(clientContract._witnetUpgradeRequest(requestId, requestReward, resultReward, blockReward, {
         from: accounts[0],
-        value: requestReward + resultReward,
+        value: requestReward + resultReward + blockReward,
       }))
     })
 
@@ -118,7 +118,7 @@ contract("UsingWitnet", accounts => {
 
     it("requester balance should decrease after rewards upgrade", async () => {
       const afterBalance = await web3.eth.getBalance(accounts[0])
-      assert(afterBalance < lastAccount0Balance - requestReward - resultReward)
+      assert(afterBalance < lastAccount0Balance - requestReward - resultReward - blockReward)
       lastAccount0Balance = afterBalance
     })
 
@@ -129,7 +129,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase after rewards upgrade", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward)
+      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward*2)
     })
 
     it("should claim eligibility for relaying the request into Witnet", async () => {
@@ -375,6 +375,18 @@ contract("UsingWitnet", accounts => {
 
       await truffleAssert.reverts(
         clientContract._witnetPostRequest(request.address, resultReward, 1, 1, {
+          from: accounts[0],
+          value: 0,
+        }),
+        "The sum of rewards overflows"
+      )
+    })
+    it("Should revert if reward amounts sum overflows 2", async () => {
+      const requestReward = web3.utils.toBN("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+      const blockReward = web3.utils.toBN("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+      await truffleAssert.reverts(
+        clientContract._witnetPostRequest(request.address, requestReward, 1, blockReward, {
           from: accounts[0],
           value: 0,
         }),

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -50,9 +50,10 @@ contract("WitnetRequestBoard", accounts => {
       const request2 = await Request.new(drBytes2)
 
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
 
       // Post first data request
-      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -61,7 +62,7 @@ contract("WitnetRequestBoard", accounts => {
       const id1 = txReceipt1.logs[0].data
 
       // Post second data request
-      const tx2 = wrbInstance.postDataRequest(request2.address, 0)
+      const tx2 = wrbInstance.postDataRequest(request2.address, 0, 0)
       const txHash2 = await waitForHash(tx2)
       const txReceipt2 = await web3.eth.getTransactionReceipt(txHash2)
       const id2 = txReceipt2.logs[0].data
@@ -87,9 +88,10 @@ contract("WitnetRequestBoard", accounts => {
       const drBytes = web3.utils.fromAscii("This is a DR")
       const request = await Request.new(drBytes)
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -134,6 +136,7 @@ contract("WitnetRequestBoard", accounts => {
       const resBytes = web3.utils.fromAscii("This is a result")
       const roots = calculateRoots(drBytes, resBytes)
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
       const epoch = 2
 
       // VRF params
@@ -145,7 +148,7 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
         from: account1,
         value: web3.utils.toWei("1", "ether"),
       })
@@ -213,7 +216,7 @@ contract("WitnetRequestBoard", accounts => {
       assert(parseInt(afterBalance1, 10) < parseInt(actualBalance1, 10))
       assert(parseInt(balanceFinal, 10) > parseInt(afterBalance2, 10))
 
-      assert.equal(0, contractBalanceAfter)
+      assert.equal(quarterEther, contractBalanceAfter)
 
       // read result bytes
       const readResBytes = await wrbInstance.readResult.call(id1)
@@ -226,9 +229,10 @@ contract("WitnetRequestBoard", accounts => {
       const drBytes2 = web3.utils.fromAscii("This is a second DR")
       const request2 = await Request.new(drBytes2)
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
 
       // post the first data request
-      const tx1 = wrbInstance.postDataRequest(request1.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request1.address, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -240,7 +244,7 @@ contract("WitnetRequestBoard", accounts => {
       assert.equal(web3.utils.hexToNumberString(id1), web3.utils.hexToNumberString("0x1"))
 
       // post the second data request
-      const tx2 = wrbInstance.postDataRequest(request2.address, 0)
+      const tx2 = wrbInstance.postDataRequest(request2.address, 0, 0)
       const txHash2 = await waitForHash(tx2)
       const txReceipt2 = await web3.eth.getTransactionReceipt(txHash2)
 
@@ -262,7 +266,7 @@ contract("WitnetRequestBoard", accounts => {
       const expectedResultId = web3.utils.hexToNumberString(hash)
 
       // post data request
-      const tx = await wrbInstance.postDataRequest(request.address, 0)
+      const tx = await wrbInstance.postDataRequest(request.address, 0, 0)
 
       // check emission of the event and its id correctness
       truffleAssert.eventEmitted(tx, "PostedRequest", (ev) => {
@@ -282,6 +286,7 @@ contract("WitnetRequestBoard", accounts => {
       const data1 = "0x" + sha.sha256(web3.utils.hexToBytes(drBytes))
       const resBytes = web3.utils.fromAscii("This is a result")
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
 
       // VRF params
       const publicKey = [data.publicKey.x, data.publicKey.y]
@@ -292,7 +297,7 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -342,6 +347,7 @@ contract("WitnetRequestBoard", accounts => {
       const request = await Request.new(drBytes)
       const resBytes = web3.utils.fromAscii("This is a result")
       const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
       const fakeBlockHeader = "0x" + sha.sha256("fake block header")
       const dummySibling = 1
 
@@ -354,7 +360,7 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -397,10 +403,14 @@ contract("WitnetRequestBoard", accounts => {
       const request = await Request.new(drBytes)
 
       // assert it reverts when rewards are higher than values sent
-      await truffleAssert.reverts(wrbInstance.postDataRequest(request.address, web3.utils.toWei("2", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      }), "Transaction value needs to be equal or greater than tally reward")
+      await truffleAssert.reverts(wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("1", "ether"),
+        web3.utils.toWei("1", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      ), "Transaction value needs to be equal or greater than tally reward")
     })
 
     it("should revert because the rewards are higher than the values sent. " +
@@ -410,10 +420,14 @@ contract("WitnetRequestBoard", accounts => {
       const request = await Request.new(drBytes)
 
       // this should pass
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -439,10 +453,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -493,10 +511,14 @@ contract("WitnetRequestBoard", accounts => {
       const epoch = 0
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -531,10 +553,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -614,10 +640,14 @@ contract("WitnetRequestBoard", accounts => {
       await waitForHash(txRelay0)
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -672,10 +702,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -724,10 +758,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -789,9 +827,10 @@ contract("WitnetRequestBoard", accounts => {
         const request = await Request.new(drBytes)
 
         const halfEther = web3.utils.toWei("0.5", "ether")
+        const quarterEther = web3.utils.toWei("0.25", "ether")
 
         // Post data request
-        const tx1 = wrbInstance.postDataRequest(request.address, halfEther, {
+        const tx1 = wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
           from: accounts[0],
           value: web3.utils.toWei("1", "ether"),
         })
@@ -825,10 +864,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -895,10 +938,14 @@ contract("WitnetRequestBoard", accounts => {
       const signature = data.signature
 
       // post data request
-      const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      })
+      const tx1 = wrbInstance.postDataRequest(
+        request.address,
+        web3.utils.toWei("0.5", "ether"),
+        web3.utils.toWei("0.5", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }
+      )
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
       const id1 = txReceipt1.logs[0].data
@@ -962,10 +1009,14 @@ contract("WitnetRequestBoard", accounts => {
         const signature = web3.utils.fromAscii("this is a fake sig")
 
         // post data request
-        const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-          from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
-        })
+        const tx1 = wrbInstance.postDataRequest(
+          request.address,
+          web3.utils.toWei("0.5", "ether"),
+          web3.utils.toWei("0.5", "ether"), {
+            from: accounts[0],
+            value: web3.utils.toWei("1", "ether"),
+          }
+        )
         const txHash1 = await waitForHash(tx1)
         const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
         const id1 = txReceipt1.logs[0].data
@@ -1026,10 +1077,14 @@ contract("WitnetRequestBoard", accounts => {
         const signature = data.signature
 
         // post data request
-        const tx1 = wrbInstance.postDataRequest(request.address, web3.utils.toWei("1", "ether"), {
-          from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
-        })
+        const tx1 = wrbInstance.postDataRequest(
+          request.address,
+          web3.utils.toWei("0.5", "ether"),
+          web3.utils.toWei("0.5", "ether"), {
+            from: accounts[0],
+            value: web3.utils.toWei("1", "ether"),
+          }
+        )
         const txHash1 = await waitForHash(tx1)
         const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
         const id1 = txReceipt1.logs[0].data
@@ -1056,8 +1111,8 @@ contract("WitnetRequestBoard", accounts => {
         })
         await waitForHash(txRelay2)
 
-        // revert when upgrading data request with wrong rewards and the DR is not yet included
         await truffleAssert.reverts(
+          // revert when upgrading data request with wrong rewards and the DR is not yet included
           wrbInstance.upgradeDataRequest(
             id1,
             web3.utils.toWei("2", "ether"),

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -216,7 +216,7 @@ contract("WitnetRequestBoard", accounts => {
       assert(parseInt(afterBalance1, 10) < parseInt(actualBalance1, 10))
       assert(parseInt(balanceFinal, 10) > parseInt(afterBalance2, 10))
 
-      assert.equal(quarterEther, contractBalanceAfter)
+      assert.equal(0, contractBalanceAfter)
 
       // read result bytes
       const readResBytes = await wrbInstance.readResult.call(id1)

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -433,10 +433,13 @@ contract("WitnetRequestBoard", accounts => {
       const id1 = txReceipt1.logs[0].data
 
       // assert it reverts when rewards are higher than values sent
-      await truffleAssert.reverts(wrbInstance.upgradeDataRequest(id1, web3.utils.toWei("2", "ether"), web3.utils.toWei("1", "ether"), {
-        from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
-      }), "Transaction value needs to be equal or greater than tally plus inclusion reward")
+      await truffleAssert.reverts(wrbInstance.upgradeDataRequest(
+        id1, web3.utils.toWei("2", "ether"),
+        web3.utils.toWei("1", "ether"), {
+          from: accounts[0],
+          value: web3.utils.toWei("1", "ether"),
+        }),
+      "Transaction value needs to be equal or greater than tally plus inclusion reward")
     })
 
     it("should revert when trying to claim a DR that was already claimed", async () => {

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -106,7 +106,7 @@ contract("WitnetRequestBoard", accounts => {
       assert.equal(web3.utils.toWei("1", "ether"), contractBalanceBefore)
 
       // upgrade reward (and thus balance of WRB)
-      const tx2 = wrbInstance.upgradeDataRequest(id1, halfEther, {
+      const tx2 = wrbInstance.upgradeDataRequest(id1, halfEther, quarterEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -410,7 +410,7 @@ contract("WitnetRequestBoard", accounts => {
           from: accounts[0],
           value: web3.utils.toWei("1", "ether"),
         }
-      ), "Transaction value needs to be equal or greater than tally reward")
+      ), "Transaction value needs to be equal or greater than tally plus inclusion reward")
     })
 
     it("should revert because the rewards are higher than the values sent. " +
@@ -433,10 +433,10 @@ contract("WitnetRequestBoard", accounts => {
       const id1 = txReceipt1.logs[0].data
 
       // assert it reverts when rewards are higher than values sent
-      await truffleAssert.reverts(wrbInstance.upgradeDataRequest(id1, web3.utils.toWei("2", "ether"), {
+      await truffleAssert.reverts(wrbInstance.upgradeDataRequest(id1, web3.utils.toWei("2", "ether"), web3.utils.toWei("1", "ether"), {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
-      }), "Transaction value needs to be equal or greater than tally reward")
+      }), "Transaction value needs to be equal or greater than tally plus inclusion reward")
     })
 
     it("should revert when trying to claim a DR that was already claimed", async () => {
@@ -1116,9 +1116,10 @@ contract("WitnetRequestBoard", accounts => {
           wrbInstance.upgradeDataRequest(
             id1,
             web3.utils.toWei("2", "ether"),
+            web3.utils.toWei("2", "ether"),
             { from: accounts[1], value: web3.utils.toWei("1", "ether") }
           ),
-          "Transaction value needs to be equal or greater than tally reward"
+          "Transaction value needs to be equal or greater than tally plus inclusion reward"
         )
 
         // report data request inclusion
@@ -1132,15 +1133,17 @@ contract("WitnetRequestBoard", accounts => {
           wrbInstance.upgradeDataRequest(
             id1,
             web3.utils.toWei("1", "ether"),
+            web3.utils.toWei("0.5", "ether"),
             { from: accounts[1], value: web3.utils.toWei("2", "ether") }
           ),
-          "Txn value should equal result reward argument (request reward already paid)"
+          "Inclusion reward should be 0 (request reward already paid)"
         )
 
         // upgrade data request with valid rewards with DR already included
         const tx4 = wrbInstance.upgradeDataRequest(id1,
+          web3.utils.toWei("0", "ether"),
           web3.utils.toWei("1", "ether"),
-          { from: accounts[0], value: web3.utils.toWei("1", "ether") }
+          { from: accounts[0], value: web3.utils.toWei("3", "ether") }
         )
         await waitForHash(tx4)
 
@@ -1153,7 +1156,8 @@ contract("WitnetRequestBoard", accounts => {
           wrbInstance.upgradeDataRequest(
             id1,
             web3.utils.toWei("1", "ether"),
-            { from: accounts[1], value: web3.utils.toWei("1", "ether") }
+            web3.utils.toWei("1", "ether"),
+            { from: accounts[1], value: web3.utils.toWei("3", "ether") }
           ),
           "Result already included"
         )

--- a/test/wrb_gas.js
+++ b/test/wrb_gas.js
@@ -271,6 +271,7 @@ contract("WitnetRequestBoard", ([
       // Initial balances
       const contractBalanceTracker = await balance.tracker(this.WitnetRequestBoard.address)
       const claimerBalanceTracker = await balance.tracker(claimer)
+      const ownerBalanceTracker = await balance.tracker(owner)
       const contractInitialBalance = await contractBalanceTracker.get()
       const claimerInitialBalance = await claimerBalanceTracker.get()
 
@@ -278,24 +279,35 @@ contract("WitnetRequestBoard", ([
       await this.BlockRelay.postNewBlock(blockHeader, epoch, roots[0], roots[1], {
         from: owner,
       })
+
+      // Get the owner balance after posting block
+      const ownerInitialBalance = await ownerBalanceTracker.get()
       await this.WitnetRequestBoard.reportDataRequestInclusion(requestId, [drOutputHash], 0, blockHeader, epoch, {
         from: other,
       })
 
-      // Check balances (contract decreased and claimer increased)
+      // Check balances (contract decreased and claimer and owner increased)
       const contractFinalBalance = await contractBalanceTracker.get()
       const claimerFinalBalance = await claimerBalanceTracker.get()
+      const ownerFinalBalance = await ownerBalanceTracker.get()
+
       expect(
         contractFinalBalance.eq(contractInitialBalance
-          .sub(ether("0.25"))
+          .sub(ether("0.375"))
         ),
-        "contract balance should have decreased after reporting dr request inclusion by 0.5 eth",
+        "contract balance should have decreased after reporting dr request inclusion by 0.375 eth",
       ).to.equal(true)
       expect(
         claimerFinalBalance.eq(claimerInitialBalance
           .add(ether("0.25"))
         ),
-        "claimer balance should have increased after reporting dr request inclusion by 0.5 eth",
+        "claimer balance should have increased after reporting dr request inclusion by 0.25 eth",
+      ).to.equal(true)
+      expect(
+        ownerFinalBalance.eq(ownerInitialBalance
+          .add(ether("0.125"))
+        ),
+        "Owner balance should have increased after reporting b lock by 0.125 eth",
       ).to.equal(true)
     })
   })
@@ -342,8 +354,11 @@ contract("WitnetRequestBoard", ([
       // Initial balances
       const contractBalanceTracker = await balance.tracker(this.WitnetRequestBoard.address)
       const claimerBalanceTracker = await balance.tracker(claimer)
+      const ownerBalanceTracker = await balance.tracker(owner)
       const contractInitialBalance = await contractBalanceTracker.get()
       const claimerInitialBalance = await claimerBalanceTracker.get()
+      // Get the owner balance after posting block
+      const ownerInitialBalance = await ownerBalanceTracker.get()
 
       // Report data request result from Witnet to WitnetRequestBoard
       const reportResultTx = await this.WitnetRequestBoard.reportResult(
@@ -366,12 +381,13 @@ contract("WitnetRequestBoard", ([
       // Check balances (contract decreased and claimer increased)
       const contractFinalBalance = await contractBalanceTracker.get()
       const claimerFinalBalance = await claimerBalanceTracker.get()
+      const ownerFinalBalance = await ownerBalanceTracker.get()
 
       expect(
         contractFinalBalance.eq(contractInitialBalance
-          .sub(ether("0.5"))
+          .sub(ether("0.625"))
         ),
-        "contract balance should have decreased after reporting dr request result by 0.5 eth",
+        "contract balance should have decreased after reporting dr request result by 0.625 eth",
       ).to.equal(true)
       expect(
         claimerFinalBalance.eq(claimerInitialBalance
@@ -379,6 +395,12 @@ contract("WitnetRequestBoard", ([
           .sub(new BN(reportResultTx.receipt.gasUsed)),
         ),
         "claimer balance should have increased after reporting dr request result by 0.5 eth",
+      ).to.equal(true)
+      expect(
+        ownerFinalBalance.eq(ownerInitialBalance
+          .add(ether("0.125"))
+        ),
+        "Owner balance should have increased after reporting b lock by 0.125 eth",
       ).to.equal(true)
     })
   })

--- a/test/wrb_gas.js
+++ b/test/wrb_gas.js
@@ -84,7 +84,7 @@ contract("WitnetRequestBoard", ([
       const contractInitialBalance = await contractBalanceTracker.get()
 
       // Post Data Request
-      const postDataRequestTx = await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      const postDataRequestTx = await this.WitnetRequestBoard.postDataRequest(this.Request.address,  ether("0.25"), ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })
@@ -114,7 +114,7 @@ contract("WitnetRequestBoard", ([
 
   describe("upgrade data request", async () => {
     beforeEach(async () => {
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      await this.WitnetRequestBoard.postDataRequest(this.Request.address,  ether("0.25"),ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })
@@ -143,7 +143,7 @@ contract("WitnetRequestBoard", ([
 
   describe("claim data request", async () => {
     beforeEach(async () => {
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.25"), ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })
@@ -225,7 +225,7 @@ contract("WitnetRequestBoard", ([
   describe("report data request inclusion", async () => {
     beforeEach(async () => {
       // Post data request
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.25"), ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })
@@ -279,13 +279,13 @@ contract("WitnetRequestBoard", ([
       const claimerFinalBalance = await claimerBalanceTracker.get()
       expect(
         contractFinalBalance.eq(contractInitialBalance
-          .sub(ether("0.5"))
+          .sub(ether("0.25"))
         ),
         "contract balance should have decreased after reporting dr request inclusion by 0.5 eth",
       ).to.equal(true)
       expect(
         claimerFinalBalance.eq(claimerInitialBalance
-          .add(ether("0.5"))
+          .add(ether("0.25"))
         ),
         "claimer balance should have increased after reporting dr request inclusion by 0.5 eth",
       ).to.equal(true)
@@ -295,7 +295,7 @@ contract("WitnetRequestBoard", ([
   describe("report data request result", async () => {
     beforeEach(async () => {
       // Post data request
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.25"), ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })
@@ -378,7 +378,7 @@ contract("WitnetRequestBoard", ([
   describe("read data request result", async () => {
     beforeEach(async () => {
       // Post data request
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.5"), {
+      await this.WitnetRequestBoard.postDataRequest(this.Request.address, ether("0.25"), ether("0.5"), {
         from: requestor,
         value: ether("1"),
       })

--- a/test/wrb_gas.js
+++ b/test/wrb_gas.js
@@ -133,7 +133,7 @@ contract("WitnetRequestBoard", ([
       const contractInitialBalance = await contractBalanceTracker.get()
 
       // Update data request (increased rewards)
-      await this.WitnetRequestBoard.upgradeDataRequest(requestId, ether("0.5"), {
+      await this.WitnetRequestBoard.upgradeDataRequest(requestId, ether("0.5"), ether("0.25"), {
         from: requestor,
         value: ether("1"),
       })

--- a/test/wrb_gas.js
+++ b/test/wrb_gas.js
@@ -84,12 +84,16 @@ contract("WitnetRequestBoard", ([
       const contractInitialBalance = await contractBalanceTracker.get()
 
       // Post Data Request
-      const postDataRequestTx = await this.WitnetRequestBoard.postDataRequest(this.Request.address,  ether("0.25"), ether("0.5"), {
-        from: requestor,
-        value: ether("1"),
-      })
-
+      const postDataRequestTx = await this.WitnetRequestBoard.postDataRequest(
+        this.Request.address,
+        ether("0.25"),
+        ether("0.5"), {
+          from: requestor,
+          value: ether("1"),
+        }
+      )
       // Check `PostedRequest` event
+
       expectEvent(
         postDataRequestTx,
         "PostedRequest",
@@ -114,10 +118,14 @@ contract("WitnetRequestBoard", ([
 
   describe("upgrade data request", async () => {
     beforeEach(async () => {
-      await this.WitnetRequestBoard.postDataRequest(this.Request.address,  ether("0.25"),ether("0.5"), {
-        from: requestor,
-        value: ether("1"),
-      })
+      await this.WitnetRequestBoard.postDataRequest(
+        this.Request.address,
+        ether("0.25"),
+        ether("0.5"), {
+          from: requestor,
+          value: ether("1"),
+        }
+      )
     })
     it("creator can upgrade existing data request (1 eth for rewards)", async () => {
       // Initial balance

--- a/test/wrb_proxy.js
+++ b/test/wrb_proxy.js
@@ -51,9 +51,9 @@ contract("Witnet Requests Board Proxy", accounts => {
       const halfEther = web3.utils.toWei("0.5", "ether")
 
       // Post the data request through the Proxy
-      const tx1 = wrbProxy.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbProxy.postDataRequest(request.address, halfEther, halfEther, {
         from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
+        value: web3.utils.toWei("1.5", "ether"),
       })
       const txHash1 = await waitForHash(tx1)
       const txReceipt1 = await web3.eth.getTransactionReceipt(txHash1)
@@ -72,7 +72,7 @@ contract("Witnet Requests Board Proxy", accounts => {
       const halfEther = web3.utils.toWei("0.5", "ether")
 
       // Post the data request through the Proxy
-      const tx1 = wrbProxy.postDataRequest(request.address, halfEther, {
+      const tx1 = wrbProxy.postDataRequest(request.address, halfEther, halfEther, {
         from: accounts[0],
         value: web3.utils.toWei("1", "ether"),
       })
@@ -101,17 +101,17 @@ contract("Witnet Requests Board Proxy", accounts => {
       const halfEther = web3.utils.toWei("0.5", "ether")
 
       // The id of the data request
-      const id2 = await wrbProxy.postDataRequest.call(request.address, halfEther, {
+      const id2 = await wrbProxy.postDataRequest.call(request.address, halfEther, halfEther, {
         from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
+        value: web3.utils.toWei("1.5", "ether"),
       })
       assert.equal(id2, 3)
 
       // Post the data request through the Proxy
       await waitForHash(
-        wrbProxy.postDataRequest(request.address, halfEther, {
+        wrbProxy.postDataRequest(request.address, halfEther, halfEther, {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.5", "ether"),
         })
       )
 
@@ -131,15 +131,15 @@ contract("Witnet Requests Board Proxy", accounts => {
       const halfEther = web3.utils.toWei("0.5", "ether")
 
       // The id of the data request with result "hello"
-      const id2 = await wrbProxy.postDataRequest.call(request.address, halfEther, {
+      const id2 = await wrbProxy.postDataRequest.call(request.address, halfEther, halfEther, {
         from: accounts[0],
-        value: web3.utils.toWei("1", "ether"),
+        value: web3.utils.toWei("1.5", "ether"),
       })
       assert.equal(id2, 4)
 
       // Post the data request through the Proxy
       await waitForHash(
-        wrbProxy.postDataRequest(request.address, halfEther, {
+        wrbProxy.postDataRequest(request.address, halfEther, halfEther, {
           from: accounts[0],
           value: web3.utils.toWei("1", "ether"),
         })

--- a/test/wrb_proxy.js
+++ b/test/wrb_proxy.js
@@ -40,7 +40,7 @@ contract("Witnet Requests Board Proxy", accounts => {
 
     it("should revert when inserting id 0", async () => {
       // It should revert because of non-existent id 0
-      await truffleAssert.reverts(wrbProxy.upgradeDataRequest(0, 1),
+      await truffleAssert.reverts(wrbProxy.upgradeDataRequest(0, 1, 1),
         "Non-existent controller for id 0")
     })
 
@@ -65,7 +65,7 @@ contract("Witnet Requests Board Proxy", accounts => {
       assert.equal(true, await wrbProxy.checkLastId.call(id1))
     })
 
-    it("should return the correposding controller of an id", async () => {
+    it("should return the corresponding controller of an id", async () => {
       // The data request to be posted
       const drBytes = web3.utils.fromAscii("This is a DR")
       const request = await RequestContract.new(drBytes)


### PR DESCRIPTION
This PR expands on https://github.com/witnet/witnet-ethereum-block-relay/pull/29 to be able to pay the block relayer. The block reward is divided in two, one for the inclusion and one for the reward.

 Missing things:

- Upgrade Request should also include an upgrade for the block relay reward.
- More extensive testing