### PR TITLE
Store gas price per dr

### DIFF
--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -389,7 +389,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
 
   /// @dev Retrieves the gas price set for a specific DR ID.
   /// @param _id The unique identifier of the data request.
-  /// @return The gas price set by the request creator
+  /// @return The gas price set by the request creator.
   function readGasPrice(uint256 _id) external view validId(_id) returns(uint256) {
     return requests[_id].gasPrice;
   }

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -194,6 +194,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     external
     payable
     payingEnough(msg.value, _inclusionReward, _tallyReward)
+    gasCostsCovered(msg.value, _inclusionReward, _tallyReward)
     override
   returns(uint256)
   {
@@ -229,7 +230,6 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     external
     payable
     payingEnough(msg.value, _inclusionReward, _tallyReward)
-    gasCostsCovered(msg.value, _inclusionReward, _tallyReward)
     resultNotIncluded(_id)
     override
   {

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -44,6 +44,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     uint256 inclusionReward;
     uint256 tallyReward;
     uint256 blockReward;
+    uint256 gasPrice;
     bytes result;
     // Block number at which the DR was claimed for the last time
     uint256 blockNumber;
@@ -201,6 +202,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     Request requestContract = Request(request.requestAddress);
     uint256 _drOutputHash = uint256(sha256(requestContract.bytecode()));
     request.drOutputHash = _drOutputHash;
+    request.gasPrice = tx.gasprice;
 
     // Push the new request into the contract state
     requests.push(request);
@@ -366,6 +368,13 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
   /// @return The result of the DR
   function readResult(uint256 _id) external view override validId(_id) returns(bytes memory) {
     return requests[_id].result;
+  }
+
+  /// @dev Retrieves the gas price set for a specific DR ID.
+  /// @param _id The unique identifier of the data request.
+  /// @return The gas price set by the request creator
+  function readGasPrice(uint256 _id) external view validId(_id) returns(uint256) {
+    return requests[_id].gasPrice;
   }
 
   /// @dev Retrieves hash of the data request transaction in Witnet.

--- a/contracts/WitnetRequestsBoard.sol
+++ b/contracts/WitnetRequestsBoard.sol
@@ -243,7 +243,7 @@ contract WitnetRequestsBoard is WitnetRequestsBoardInterface {
     } else {
       requests[_id].inclusionReward = SafeMath.add(requests[_id].inclusionReward, _inclusionReward);
       requests[_id].tallyReward = SafeMath.add(requests[_id].tallyReward, _tallyReward);
-      requests[_id].blockReward = SafeMath.add(requests[_id].blockReward,  SafeMath.sub(msg.value, SafeMath.add(_inclusionReward, _tallyReward)));
+      requests[_id].blockReward = SafeMath.add(requests[_id].blockReward, SafeMath.sub(msg.value, SafeMath.add(_inclusionReward, _tallyReward)));
     }
   }
 

--- a/test/using_witnet.js
+++ b/test/using_witnet.js
@@ -20,10 +20,10 @@ contract("UsingWitnet", accounts => {
     const block1Hash = 0x123456
     const block2Hash = 0xabcdef
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-
-    const requestReward = 7000000000000000
-    const resultReward = 1500000000000000
-    const blockReward = 1500000000000000
+    const requestReward = web3.utils.toWei("0.5", "ether")
+    const resultReward = web3.utils.toWei("0.25", "ether")
+    const blockReward = web3.utils.toWei("0.25", "ether")
+    const overalReward = web3.utils.toWei("1", "ether")
 
     let witnet, clientContract, wrb, wrbProxy, blockRelay, request, requestId, requestHash, result, blockRelayProxy
     let lastAccount0Balance, lastAccount1Balance
@@ -62,7 +62,7 @@ contract("UsingWitnet", accounts => {
         resultReward,
         blockReward, {
           from: accounts[0],
-          value: requestReward + resultReward + blockReward,
+          value: overalReward,
         }
       ))
       const expectedId = "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -97,13 +97,13 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, requestReward + resultReward + blockReward)
+      assert.equal(wrbBalance, overalReward)
     })
 
     it("should upgrade the rewards of a existing Witnet request", async () => {
       await returnData(clientContract._witnetUpgradeRequest(requestId, requestReward, resultReward, blockReward, {
         from: accounts[0],
-        value: requestReward + resultReward + blockReward,
+        value: overalReward,
       }))
     })
 
@@ -129,7 +129,7 @@ contract("UsingWitnet", accounts => {
 
     it("WRB balance should increase after rewards upgrade", async () => {
       const wrbBalance = await web3.eth.getBalance(wrb.address)
-      assert.equal(wrbBalance, (requestReward + resultReward) * 2 + blockReward * 2)
+      assert.equal(wrbBalance, overalReward * 2)
     })
 
     it("should claim eligibility for relaying the request into Witnet", async () => {
@@ -234,9 +234,10 @@ contract("UsingWitnet", accounts => {
     const block4Hash = 0x000004
     const nullHash = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-    const requestReward = 7000000000000000
-    const resultReward = 1500000000000000
-    const blockReward = 1500000000000000
+    const requestReward = web3.utils.toWei("0.5", "ether")
+    const resultReward = web3.utils.toWei("0.25", "ether")
+    const blockReward = web3.utils.toWei("0.25", "ether")
+    const overalReward = web3.utils.toWei("1", "ether")
 
     let witnet, clientContract, wrb, blockRelay, blockRelayProxy, request, requestId, requestHash, result
 
@@ -271,7 +272,7 @@ contract("UsingWitnet", accounts => {
         resultReward,
         blockReward, {
           from: accounts[0],
-          value: requestReward + resultReward + blockReward,
+          value: overalReward,
         }
       ))
       assert.equal(requestId.toString(16), "0x0000000000000000000000000000000000000000000000000000000000000001")

--- a/test/wrb.js
+++ b/test/wrb.js
@@ -62,7 +62,10 @@ contract("WitnetRequestBoard", accounts => {
       const id1 = txReceipt1.logs[0].data
 
       // Post second data request
-      const tx2 = wrbInstance.postDataRequest(request2.address, 0, 0)
+      const tx2 = wrbInstance.postDataRequest(request2.address, halfEther, quarterEther, {
+        from: accounts[0],
+        value: web3.utils.toWei("1", "ether"),
+      })
       const txHash2 = await waitForHash(tx2)
       const txReceipt2 = await web3.eth.getTransactionReceipt(txHash2)
       const id2 = txReceipt2.logs[0].data
@@ -78,7 +81,7 @@ contract("WitnetRequestBoard", accounts => {
       )
 
       assert(parseInt(afterBalance1, 10) < parseInt(actualBalance1, 10))
-      assert.equal(web3.utils.toWei("1", "ether"), contractBalanceAfter)
+      assert.equal(web3.utils.toWei("2", "ether"), contractBalanceAfter)
 
       assert.equal(drBytes, readDrBytes)
       assert.equal(drBytes2, readDrBytes2)
@@ -244,7 +247,10 @@ contract("WitnetRequestBoard", accounts => {
       assert.equal(web3.utils.hexToNumberString(id1), web3.utils.hexToNumberString("0x1"))
 
       // post the second data request
-      const tx2 = wrbInstance.postDataRequest(request2.address, 0, 0)
+      const tx2 = wrbInstance.postDataRequest(request2.address, halfEther, quarterEther, {
+        from: accounts[0],
+        value: web3.utils.toWei("1", "ether"),
+      })
       const txHash2 = await waitForHash(tx2)
       const txReceipt2 = await web3.eth.getTransactionReceipt(txHash2)
 
@@ -264,9 +270,14 @@ contract("WitnetRequestBoard", accounts => {
       const request = await Request.new(drBytes)
       const hash = "0x1"
       const expectedResultId = web3.utils.hexToNumberString(hash)
+      const halfEther = web3.utils.toWei("0.5", "ether")
+      const quarterEther = web3.utils.toWei("0.25", "ether")
 
       // post data request
-      const tx = await wrbInstance.postDataRequest(request.address, 0, 0)
+      const tx = await wrbInstance.postDataRequest(request.address, halfEther, quarterEther, {
+        from: accounts[0],
+        value: web3.utils.toWei("1", "ether"),
+      })
 
       // check emission of the event and its id correctness
       truffleAssert.eventEmitted(tx, "PostedRequest", (ev) => {
@@ -425,7 +436,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -461,7 +472,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -519,7 +530,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -561,7 +572,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -648,7 +659,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -710,7 +721,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -766,7 +777,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -872,7 +883,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -946,7 +957,7 @@ contract("WitnetRequestBoard", accounts => {
         web3.utils.toWei("0.5", "ether"),
         web3.utils.toWei("0.5", "ether"), {
           from: accounts[0],
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("1.25", "ether"),
         }
       )
       const txHash1 = await waitForHash(tx1)
@@ -1017,7 +1028,7 @@ contract("WitnetRequestBoard", accounts => {
           web3.utils.toWei("0.5", "ether"),
           web3.utils.toWei("0.5", "ether"), {
             from: accounts[0],
-            value: web3.utils.toWei("1", "ether"),
+            value: web3.utils.toWei("1.25", "ether"),
           }
         )
         const txHash1 = await waitForHash(tx1)
@@ -1085,7 +1096,7 @@ contract("WitnetRequestBoard", accounts => {
           web3.utils.toWei("0.5", "ether"),
           web3.utils.toWei("0.5", "ether"), {
             from: accounts[0],
-            value: web3.utils.toWei("1", "ether"),
+            value: web3.utils.toWei("1.25", "ether"),
           }
         )
         const txHash1 = await waitForHash(tx1)


### PR DESCRIPTION
This PR:

- Stores the gas price set by the requestor in the DR information structure.
- Adds a getter to retrieve such a gas price.
- Rejects the DR if the rewards do not match the expected gas times the gas price set.