### PR TITLE
fix code errors

### DIFF
--- a/contracts/WitnetRequestsBoardProxy.sol
+++ b/contracts/WitnetRequestsBoardProxy.sol
@@ -114,7 +114,7 @@ contract WitnetRequestsBoardProxy {
 
   /// @notice Upgrades the Witnet Requests Board if the current one is upgradeable.
   /// @param _newAddress address of the new block relay to upgrade.
-  function upgradeWitnetRequestsBoard(address _newAddress) public notIdentical(_newAddress) {
+  function upgradeWitnetRequestsBoard(address _newAddress) external notIdentical(_newAddress) {
     // Require the WRB is upgradable
     require(witnetRequestsBoardInstance.isUpgradable(msg.sender), "The upgrade has been rejected by the current implementation");
     // Map the currentLastId to the corresponding witnetRequestsBoardAddress and add it to controllers

--- a/test/TestActiveBridgeSet.sol
+++ b/test/TestActiveBridgeSet.sol
@@ -165,7 +165,7 @@ contract TestActiveBridgeSet {
 // Proxy contract for testing throws
 contract ThrowProxy {
   address public target;
-  bytes data;
+  bytes internal data;
 
   constructor (address _target) public {
     target = _target;

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -186,7 +186,7 @@ contract TestBuffer {
 // Proxy contract for testing throws
 contract ThrowProxy {
   address public target;
-  bytes data;
+  bytes internal data;
 
   constructor (address _target) public {
     target = _target;


### PR DESCRIPTION
Close #147 

```
·----------------------------------------------·--------------·-------·
|                Error Type                    |  Occurences  | FIXED |
·······································································
| Hardcoded address                            |           1  |     0 |
·······································································
| Multiplication after division                |           1  |     0 |
·······································································
| Costly loop                                  |           5  |     0 |
·······································································
| Locked money                                 |           5  |     0 |
·······································································
| Compiler version not fixed                   |           7  |     0 |
·······································································
| Pure-functions should not read/change state  |           9  |     0 |
·······································································
| Upgrade code to Solidity 0.5.x               |           1  |     1 |
·······································································
| Prefer external to public visibility level   |          27  |     1 |
·······································································
| Use of assembly                              |          10  |     0 |
·······································································
| Implicit visibility level                    |           2  |     1 |
·----------------------------------------------·--------------·-------·
| TOTAL                                        |          68  |     3 |
·----------------------------------------------·--------------·-------·
```

### Hardcoded address (1): NOT FIXED

The error is found in a test and it not an address but an `uint128`.


### Multiplication after division (1): NOT FIXED

The condition was built in order to maximize the precision and to avoid an integer overflow.


### Costly loop (5): NOT FIXED

The function `checkDataRequestsClaimability(uint256[] calldata _ids)` is used externally by Witnet bridges in order to check from the contract if they could claim data requests. There is no need to create transaction and spend gas in order to read the contract state. Additionally, in case of being called from an on-chain transaction, gas cost can be limited by modifying the length of the function argument `_ids` (e.g. checking a lower number of data request identifiers).

The function `claimDataRequests(uint256[] memory _ids, ...)` was design to allow developers to claim several data requests using the same proof of eligibility, thus reducing gas costs if developer wants to claim more than one data request. Nevertheless, gas cost can be limited by modifying the length of the function argument `_ids` (e.g. checking a lower number of data request identifiers).

All potentially constly loops in CBOR.sol are inherited from the specification in RFC 7049 and are therefore unavoidable. Because of the way in which CBOR is designed to operate, the number of iterations is determined by the value of the first bytes in the _cborValue.buffer input.
This could theoretically cause the loop to iterate enough times for the transaction to hit the gas limit. May a third-party contract's business logic depend on this piece of could, it could become unreachable forever. However, there are only two circumstances in which we may find a _cborValue.buffer which specified a significantly high length:

Ill-intended nonconforming CBOR values that may be specially crafted to force this situation by specifying a declared length that exceeds the actual length of the input bytes. In this case, the algorithm will most surely panic because of shortage of bytes before hitting any gas limit.
CBOR values that are actually huge in size. Generally speaking, these loops are indeed not guarded against that possibility. However, specifically in our case, gas limits would be most surely reached by the preceding transaction supplying the input bytes and storing them into WitnetRequestsBoard.

### Locked money (5): NOT FIXED

SmartDec tool complains about a smart contract having payable methods but without .send, .value, or .transfer methods inside it.

In our case, 4 out of 5 errors are errors in Test Helper smart contracts.
The remaining error appears in `WitnetRequestBoardProxy` and it is considered as a false positive because the tool is not detecting the [new `.value` syntax](https://vomtom.at/solidity-0-6-4-and-call-value-curly-brackets/).


### Compiler version (7): NOT FIXED

Libraries and inherited contracts have been instructed to allow any versions from 0.6.0 to less than 0.7.0.


### Pure functions should not read/change state (9): NOT FIXED

These errors arise when pure functions are potentially changing the state of the contract. Since the tool does not understand assembly language, it does not have a method to derive whether the code is modifying the state. In our cases none of our assembly code is modifying the state of the contracts, but rather input arguments or local variables.

### Prefer external to public visibility level (27): PARTIALLY FIXED (1)

All functions which have as arguments native solidity types have been renamed external.

The tool does not detect public functions as being used in modifiers, so it thinks they should be external. However, fucntions being used in modifiers should be treated as public as they are used by the contract itself.

There exists a special case in the `claimDataRequests` function. This function should be external, but making it external increases the stack (bytes types in calldata need two stack slots vs one in memory) and prevents as from having that many local variables. 


### Upgrade code to Solidity 0.5.x (1): FIXED

This error was fixed by changing the `bytes data` field in contract `ThrowProxy` to `internal`.


### Use of assemby (10): NOT FIXED

The tool, whenever assembly code is detected, triggers an alarm. These will not be fixed as the assembly code is necessary for the Buffer library and a signature verification.


### Implicit visibility level (2): PARTIALLY FIXED (1)

This error was fixed by changing the `bytes data` field in contract `ThrowProxy` to `internal`.
