### PR TITLE
Chore: Generate 0.4.1 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository provides several deployable contracts:
 
-- `WitnetParseLib`, helper library useful for parsing Witnet-solved results to previously posted Witnet Data Requests.
+- `WitnetParserLib`, helper library useful for parsing Witnet-solved results to previously posted Witnet Data Requests.
 - `WitnetProxy`, a delegate-proxy contract that routes Witnet Data Requests to a currently active `WitnetRequestBoard` implementation.
 - Multiple implementations of the `WitnetRequestBoard` interface (WRB), which declares all required functionality to relay encapsulated [Witnet Data Requests](https://docs.witnet.io/protocol/data-requests/overview/) from Ethereum to the Witnet mainnet, as well as to relay Witnet-solved results back to Ethereum.
 
@@ -19,18 +19,18 @@ The repository also provides:
 
 `WitnetProxy` is an upgradable delegate-proxy contract that routes Witnet Data Requests coming from a `UsingWitnet`-inheriting contract to a currently active `WitnetRequestBoard` implementation. 
 
-This table contains all the `WinetProxy` instances that act as entry-points for the latest versions of the `WitnetRequestBoard` approved and deployed by the [**Witnet Foundation**](https://witnet.io), and that actually integrates with the **Witnet mainnet** from the following EVM-compatible blockchains:
+The following table contains all the `WinetProxy` instances that act as entry-points for the latest versions of the `WitnetRequestBoard` approved and deployed by the [**Witnet Foundation**](https://witnet.foundation), and that actually integrates with the **Witnet mainnet** from the currently supported EVM-compatible blockchains.
 
-  | Blockchain   | Network   | `WitnetProxy` address
-  | ------------ | --------- | ---------------------
-  | **Ethereum** | Rinkeby   | `` 
-  |              | Göerli    | `` 
+  | Blockchain   | Network   | `WitnetProxy` |
+  | ------------ | --------- | :-----------: |
+  | **Ethereum** | Rinkeby   | `0x6cE42a35C61ccfb42907EEE57eDF14Bb69C7fEF4` 
+  |              | Göerli    | `0xb58D05247d16b3F1BD6B59c52f7f61fFef02BeC8` 
   |              | Mainnet   | `` 
   | ------------ | --------- | ---------------------
-  | **Conflux**  | Testnet   | `` 
+  | **Conflux**  | Testnet   | `cfxtest:acfnpy71hjhamy075xyps56124zje5154ux9nte7vt` 
   |              | Mainnet   | `` 
   | ------------ | --------- | ---------------------
-  | **OMGX.L2**  | Rinkeby   | `` 
+  | **BOBA.L2**  | Rinkeby   | `0xA2F4f5290F9cfD3a17Cfa82f2a2fD3E5c05d1442` 
   |              | Mainnet   | `` 
   | ------------ | --------- | ---------------------
 
@@ -244,7 +244,7 @@ contract MyContract is UsingWitnet {
     // TODO
   }
 
-  function myOwnDrPost() public returns(uint256 _drTrackId) {
+  function myOwnDrPost() public payable returns (uint256 _drTrackId) {
     _drTrackId = witnetPostRequest{value: msg.value}(myRequest);
   }
 }
@@ -262,17 +262,17 @@ Please, have a look at the [`witnet/truffle-box`](https://github.com/witnet/truf
 ·······································|·················|·············|·············|·············|··············|··············
 |  Contract                            ·  Method         ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetProxy                         ·  upgradeTo      ·          -  ·          -  ·     121146  ·           1  ·          -  │
+|  WitnetProxy                         ·  upgradeTo      ·          -  ·          -  ·     121057  ·           1  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault  ·  deleteQuery    ·      38352  ·      41633  ·      40403  ·           8  ·          -  │
+|  WitnetRequestBoardTrustableDefault  ·  deleteQuery    ·          -  ·          -  ·      40769  ·           8  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault  ·  destruct       ·          -  ·          -  ·      13582  ·           2  ·          -  │
+|  WitnetRequestBoardTrustableDefault  ·  destruct       ·          -  ·          -  ·      13593  ·           2  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault  ·  initialize     ·          -  ·          -  ·      75077  ·          30  ·          -  │
+|  WitnetRequestBoardTrustableDefault  ·  initialize     ·          -  ·          -  ·      75099  ·          30  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault  ·  postRequest    ·     144650  ·     196484  ·     164280  ·          33  ·          -  │
+|  WitnetRequestBoardTrustableDefault  ·  postRequest    ·     144650  ·     196484  ·     172132  ·          33  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault  ·  reportResult   ·     119210  ·     121359  ·     119806  ·          18  ·          -  │
+|  WitnetRequestBoardTrustableDefault  ·  reportResult   ·     120535  ·     120547  ·     120542  ·          18  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
 |  WitnetRequestBoardTrustableDefault  ·  upgradeReward  ·      31341  ·      36484  ·      34770  ·           6  ·          -  │
 ·······································|·················|·············|·············|·············|··············|··············
@@ -284,7 +284,7 @@ Please, have a look at the [`witnet/truffle-box`](https://github.com/witnet/truf
 ·························································|·············|·············|·············|··············|··············
 |  WitnetProxy                                           ·          -  ·          -  ·     587730  ·       8.7 %  ·          -  │
 ·························································|·············|·············|·············|··············|··············
-|  WitnetRequestBoardTrustableDefault                    ·          -  ·          -  ·    3699603  ·      55.1 %  ·          -  │
+|  WitnetRequestBoardTrustableDefault                    ·          -  ·          -  ·    3690955  ·      54.9 %  ·          -  │
 ·--------------------------------------------------------|-------------|-------------|-------------|--------------|-------------·
 ```
 

--- a/migrations/witnet.addresses.json
+++ b/migrations/witnet.addresses.json
@@ -1,16 +1,16 @@
 {
   "default": {
     "ethereum.goerli" : {
-      "WitnetParserLib": "",
-      "WitnetRequestBoard": ""
+      "WitnetParserLib": "0x46cF0c52f7B2e76F1E95fe163B98F92413f1d5A4",
+      "WitnetRequestBoard": "0xb58D05247d16b3F1BD6B59c52f7f61fFef02BeC8"
     },
     "ethereum.kovan": {
       "WitnetParserLib": "",
       "WitnetRequestBoard": ""
     },
     "ethereum.rinkeby" : {
-      "WitnetParserLib": "",
-      "WitnetRequestBoard": ""
+      "WitnetParserLib": "0x14b5cAC222d55Cb11CC9fE5Fbf6793177B3048F6",
+      "WitnetRequestBoard": "0x6cE42a35C61ccfb42907EEE57eDF14Bb69C7fEF4"
     },
     "ethereum.mainnet": {
       "WitnetParserLib": "",
@@ -19,8 +19,8 @@
   },
   "conflux": {
     "conflux.testnet": {
-      "WitnetParserLib": "",
-      "WitnetRequestBoard": ""
+      "WitnetParserLib": "0x824ae04f47C6a8C08CbfE140fbd273Eb2E275795",
+      "WitnetRequestBoard": "0x8aB653B73a0e0552dDdce8c76F97c6AA826EFbD4"
     },
     "conflux.tethys": {
       "WitnetParserLib": "",
@@ -28,11 +28,11 @@
     }
   },
   "boba": {
-    "test": {
-      "WitnetParserLib": "",
-      "WitnetRequestBoard": ""
-    },
     "boba.rinkeby": {
+      "WitnetParserLib": "0xdF4Df677F645Fe603a883Ad3f2Db03EDFDd75F5C",
+      "WitnetRequestBoard": "0xA2F4f5290F9cfD3a17Cfa82f2a2fD3E5c05d1442"
+    },
+    "boba.mainnet": {
       "WitnetParserLib": "",
       "WitnetRequestBoard": ""
     }

--- a/migrations/witnet.settings.js
+++ b/migrations/witnet.settings.js
@@ -103,14 +103,6 @@ module.exports = {
       },
     },
     boba: {
-      test: {
-        network_id: 28,
-        host: "localhost",
-        port: 7545,
-        networkCheckTimeout: 1000,
-        gasPrice: 15000000,
-        gasLimit: 150000000,
-      },
       "boba.rinkeby": {
         network_id: 28,
         host: "localhost",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "witnet-ethereum-bridge",
-  "version": "0.4.1",
-  "description": "Witnet Solidity contract for EVM-compatible networks",
+  "version": "0.4.2",
+  "description": "Witnet Bridge Solidity contracts for EVM-compatible networks",
   "main": "",
   "scripts": {
     "addresses": "node ./scripts/addresses.js 2>&1",


### PR DESCRIPTION
Deploy latest version into all supported testnets:

- [ ] ethereum.goerli
- [x] ethereum.rinkeby
- [x] conflux.testnet
- [x] boba.rinkeby